### PR TITLE
Restrict dtypes, bugfixes, test basic tensor functions

### DIFF
--- a/applications/learn_mnist.py
+++ b/applications/learn_mnist.py
@@ -39,21 +39,54 @@ class TinyConvNet:
         return x.dot(self.l1).log_softmax()
 
 
-if __name__ == "__main__":
-    NUM_STEPS = 100
-    BS = 128
-    LR = 0.001
+# if __name__ == "__main__":
+#     NUM_STEPS = 100
+#     BS = 128
+#     LR = 0.001
 
+#     X_train, Y_train, X_test, Y_test = fetch_mnist()
+#     model = TinyConvNet()
+#     opt = optimizer.Adam([model.c1, model.c2, model.l1], lr=LR)
+
+#     with Tensor.train():
+#         for step in range(NUM_STEPS):
+#             # Get sample batches
+#             samp = np.random.randint(0, X_train.shape[0], size=(BS))
+#             xb, yb = Tensor(X_train[samp], requires_grad=False), Tensor(Y_train[samp])
+#             # Train
+#             out = model(xb)
+#             loss = out.sparse_categorical_crossentropy(yb)
+#             opt.zero_grad()
+#             loss.backward()
+#             opt.step()
+#             # Evaluate Train
+#             y_preds = out.numpy().argmax(axis=-1)
+#             acc = (y_preds == yb.numpy()).mean()
+#             if step == 0 or (step + 1) % 20 == 0:
+#                 print(f"Step {step+1:<3} | Loss: {loss.numpy():.4f} | Train Acc: {acc:.3f}")
+
+#     # Evaluate Test
+#     acc = 0
+#     for i in range(0, len(Y_test), BS):
+#         xb, yb = Tensor(X_test[i : i + BS], requires_grad=False), Tensor(Y_test[i : i + BS])
+#         out = model(xb)
+#         preds = out.argmax(axis=-1)
+#         acc += (preds == yb).sum().numpy()
+#     acc /= len(Y_test)
+#     print(f"Test Acc: {acc:.3f}")
+
+
+
+def train_and_evaluate_mnist(num_steps=100, batch_size=128, learning_rate=0.001):
     X_train, Y_train, X_test, Y_test = fetch_mnist()
     model = TinyConvNet()
-    opt = optimizer.Adam([model.c1, model.c2, model.l1], lr=LR)
+    opt = optimizer.Adam([model.c1, model.c2, model.l1], lr=learning_rate)
 
     with Tensor.train():
-        for step in range(NUM_STEPS):
-            # Get sample batches
-            samp = np.random.randint(0, X_train.shape[0], size=(BS))
+        for step in range(num_steps):
+            samp = np.random.randint(0, X_train.shape[0], size=(batch_size))
             xb, yb = Tensor(X_train[samp], requires_grad=False), Tensor(Y_train[samp])
-            # Train
+            
             out = model(xb)
             loss = out.sparse_categorical_crossentropy(yb)
             opt.zero_grad()
@@ -66,11 +99,18 @@ if __name__ == "__main__":
                 print(f"Step {step+1:<3} | Loss: {loss.numpy():.4f} | Train Acc: {acc:.3f}")
 
     # Evaluate Test
-    acc = 0
-    for i in range(0, len(Y_test), BS):
-        xb, yb = Tensor(X_test[i : i + BS], requires_grad=False), Tensor(Y_test[i : i + BS])
+    test_accuracy = 0
+    for i in range(0, len(Y_test), batch_size):
+        xb, yb = Tensor(X_test[i : i + batch_size], requires_grad=False), Tensor(Y_test[i : i + batch_size])
         out = model(xb)
         preds = out.argmax(axis=-1)
-        acc += (preds == yb).sum().numpy()
-    acc /= len(Y_test)
-    print(f"Test Acc: {acc:.3f}")
+        test_accuracy += (preds == yb).sum().numpy()
+    test_accuracy /= len(Y_test)
+    return test_accuracy
+
+
+
+if __name__ == "__main__":
+    # Only execute if this script is run directly
+    test_accuracy = train_and_evaluate_mnist()
+    print(f"Test Acc: {test_accuracy:.3f}")

--- a/applications/learn_mnist.py
+++ b/applications/learn_mnist.py
@@ -15,9 +15,9 @@ def fetch_mnist(for_convolution=True):
     BASE = os.path.dirname(__file__) + "/datasets"
     
     X_train = parse(BASE + "/mnist/train-images-idx3-ubyte.gz")[0x10:].reshape((-1, 28 * 28)).astype(np.float32)
-    Y_train = parse(BASE + "/mnist/train-labels-idx1-ubyte.gz")[8:]
+    Y_train = parse(BASE + "/mnist/train-labels-idx1-ubyte.gz")[8:].astype(np.int32)
     X_test = parse(BASE + "/mnist/t10k-images-idx3-ubyte.gz")[0x10:].reshape((-1, 28 * 28)).astype(np.float32)
-    Y_test = parse(BASE + "/mnist/t10k-labels-idx1-ubyte.gz")[8:]
+    Y_test = parse(BASE + "/mnist/t10k-labels-idx1-ubyte.gz")[8:].astype(np.int32)
     if for_convolution:
         X_train = X_train.reshape(-1, 1, 28, 28)
         X_test = X_test.reshape(-1, 1, 28, 28)

--- a/applications/learn_mnist.py
+++ b/applications/learn_mnist.py
@@ -24,7 +24,7 @@ def fetch_mnist(for_convolution=True):
     return X_train, Y_train, X_test, Y_test
 
 
-class TinyConvNet:
+class ConvNet:
     def __init__(self):
         # https://keras.io/examples/vision/mnist_convnet/
         kernel_sz = 3
@@ -42,7 +42,7 @@ class TinyConvNet:
 
 def train_and_evaluate_mnist(num_steps=100, batch_size=128, learning_rate=0.001):
     X_train, Y_train, X_test, Y_test = fetch_mnist()
-    model = TinyConvNet()
+    model = ConvNet()
     opt = optimizer.Adam([model.c1, model.c2, model.l1], lr=learning_rate)
 
     with Tensor.train():

--- a/applications/learn_mnist.py
+++ b/applications/learn_mnist.py
@@ -13,6 +13,7 @@ def fetch_mnist(for_convolution=True):
 
     # parse = lambda file: np.frombuffer(gzip.open(file).read(), dtype=np.uint8).copy()
     BASE = os.path.dirname(__file__) + "/datasets"
+    
     X_train = parse(BASE + "/mnist/train-images-idx3-ubyte.gz")[0x10:].reshape((-1, 28 * 28)).astype(np.float32)
     Y_train = parse(BASE + "/mnist/train-labels-idx1-ubyte.gz")[8:]
     X_test = parse(BASE + "/mnist/t10k-images-idx3-ubyte.gz")[0x10:].reshape((-1, 28 * 28)).astype(np.float32)
@@ -37,44 +38,6 @@ class TinyConvNet:
         x = x.conv2d(self.c2).relu().max_pool2d()
         x = x.reshape(shape=[x.shape[0], -1])
         return x.dot(self.l1).log_softmax()
-
-
-# if __name__ == "__main__":
-#     NUM_STEPS = 100
-#     BS = 128
-#     LR = 0.001
-
-#     X_train, Y_train, X_test, Y_test = fetch_mnist()
-#     model = TinyConvNet()
-#     opt = optimizer.Adam([model.c1, model.c2, model.l1], lr=LR)
-
-#     with Tensor.train():
-#         for step in range(NUM_STEPS):
-#             # Get sample batches
-#             samp = np.random.randint(0, X_train.shape[0], size=(BS))
-#             xb, yb = Tensor(X_train[samp], requires_grad=False), Tensor(Y_train[samp])
-#             # Train
-#             out = model(xb)
-#             loss = out.sparse_categorical_crossentropy(yb)
-#             opt.zero_grad()
-#             loss.backward()
-#             opt.step()
-#             # Evaluate Train
-#             y_preds = out.numpy().argmax(axis=-1)
-#             acc = (y_preds == yb.numpy()).mean()
-#             if step == 0 or (step + 1) % 20 == 0:
-#                 print(f"Step {step+1:<3} | Loss: {loss.numpy():.4f} | Train Acc: {acc:.3f}")
-
-#     # Evaluate Test
-#     acc = 0
-#     for i in range(0, len(Y_test), BS):
-#         xb, yb = Tensor(X_test[i : i + BS], requires_grad=False), Tensor(Y_test[i : i + BS])
-#         out = model(xb)
-#         preds = out.argmax(axis=-1)
-#         acc += (preds == yb).sum().numpy()
-#     acc /= len(Y_test)
-#     print(f"Test Acc: {acc:.3f}")
-
 
 
 def train_and_evaluate_mnist(num_steps=100, batch_size=128, learning_rate=0.001):

--- a/edugrad/_tensor/tensor_broadcasted_binary_mlops.py
+++ b/edugrad/_tensor/tensor_broadcasted_binary_mlops.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 
-from edugrad.helpers import dtypes
+from edugrad.dtypes import dtypes
 import edugrad.function as function
 
 

--- a/edugrad/_tensor/tensor_combine_segment.py
+++ b/edugrad/_tensor/tensor_combine_segment.py
@@ -7,7 +7,7 @@ from edugrad.helpers import all_int
 
 
 def cat(tensor, *args, dim) -> Tensor:
-    from edugrad._tensor import Tensor
+    from edugrad.tensor import Tensor
 
     dim = (dim + len(tensor.shape)) if dim < 0 else dim
     assert all(

--- a/edugrad/_tensor/tensor_create.py
+++ b/edugrad/_tensor/tensor_create.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 import time
 import math
 
-from edugrad.helpers import argfix, DType, prod, shape_int, dtypes
+from edugrad.dtypes import DType, dtypes
+from edugrad.helpers import argfix, prod, shape_int
 from edugrad.data import TensorData
 from edugrad.ops import LoadOps
 

--- a/edugrad/_tensor/tensor_index_slice.py
+++ b/edugrad/_tensor/tensor_index_slice.py
@@ -36,7 +36,7 @@ from edugrad._tensor.tensor_reshape import pad, _flatten
 def __getitem__(
     tensor: "Tensor", val
 ) -> "Tensor":  # val: Union[int, slice, Tensor, None, Ellipsis, Tuple[Union[int, slice, Tensor, None, Ellipsis], ...]]
-    from edugrad._tensor import Tensor
+    from edugrad.tensor import Tensor
 
     def normalize_int(e, i, dim_sz):
         if -dim_sz <= e < dim_sz:
@@ -142,10 +142,11 @@ def __setitem__(tensor: "Tensor", s, v):
 
 
 # NOTE: using slice is discouraged and things should migrate to pad and shrink
-def slice(tensor: "Tensor", arg: Sequence[Optional[Tuple[int, shape_int]]], value: float) -> "Tensor":
+def tslice(tensor: "Tensor", arg: Sequence[Optional[Tuple[int, shape_int]]], value: float = 0) -> "Tensor":
+    from edugrad.tensor import Tensor
     arg_ = tuple([a if a is not None else (0, s) for s, a in zip(tensor.shape, arg)])
     padding = tuple([(max(0, -p[0]), max(0, p[1] - tensor.shape[i])) for i, p in enumerate(arg_)])
-    return pad(tensor, padding, value=value).shrink(
+    return tensor.pad(padding, value=value).shrink(
         tuple([(p[0] + padding[i][0], p[1] + padding[i][0]) for i, p in enumerate(arg_)])
     )
     # FIXME: tensor.pad(padding, value=value)... returns None...

--- a/edugrad/_tensor/tensor_index_slice.py
+++ b/edugrad/_tensor/tensor_index_slice.py
@@ -1,7 +1,8 @@
 from typing import Sequence, Optional, Tuple
 from collections import defaultdict
 
-from edugrad.helpers import shape_int, dtypes
+from edugrad.dtypes import dtypes
+from edugrad.helpers import shape_int
 from edugrad._tensor.tensor_reshape import pad, _flatten
 
 

--- a/edugrad/_tensor/tensor_nn.py
+++ b/edugrad/_tensor/tensor_nn.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 import math
 
-from edugrad.helpers import make_pair, flatten, dtypes, all_int, shape_int
+from edugrad.dtypes import dtypes
+from edugrad.helpers import make_pair, flatten, all_int, shape_int
 
 
 # processing ops

--- a/edugrad/_tensor/tensor_reduce.py
+++ b/edugrad/_tensor/tensor_reduce.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from edugrad.helpers import dtypes, prod, all_int
+
+from edugrad.dtypes import dtypes
+from edugrad.helpers import prod, all_int
 from edugrad.function import Function
 import edugrad.function as function
 

--- a/edugrad/_tensor/tensor_reduce.py
+++ b/edugrad/_tensor/tensor_reduce.py
@@ -46,8 +46,8 @@ def _reduce(self, fxn: type[Function], axis: int | tuple[int, ...] | None, keepd
     return ret if keepdim else ret.reshape(shape=shape)
 
 
+# ----------------------------------------------------------------------------------------------------------------------
 # Functions that use the generic _reduce method for specific reduction operations.
-
 
 def tsum(tensor: Tensor, axis, keepdim):
     """Computes the sum of elements over the specified axis."""
@@ -76,9 +76,8 @@ def std(tensor: Tensor, axis, keepdim, correction):
     square_sum = ((tensor - tensor.mean(axis=axis, keepdim=True)).square()).sum(axis=axis, keepdim=keepdim)
     return square_sum.div(prod(tensor.shape) / prod(square_sum.shape) - correction).sqrt()
 
-
+# ----------------------------------------------------------------------------------------------------------------------
 # Functions for softmax and its logarithmic variant, as well as argmax and argmin operations.
-
 
 def _softmax(tensor: Tensor, axis):
     """Helper function to compute softmax components."""

--- a/edugrad/_tensor/tensor_reduce.py
+++ b/edugrad/_tensor/tensor_reduce.py
@@ -61,8 +61,7 @@ def tmax(tensor: Tensor, axis, keepdim):
 
 def tmin(tensor: Tensor, axis, keepdim):
     """Computes the minimum value of elements over the specified axis."""
-    return -((-tensor).tmax((-tensor), axis=axis, keepdim=keepdim))
-
+    return -tmax((-tensor), axis=axis, keepdim=keepdim)
 
 def mean(tensor: Tensor, axis, keepdim):
     """Computes the mean of elements over the specified axis."""

--- a/edugrad/_tensor/tensor_reshape.py
+++ b/edugrad/_tensor/tensor_reshape.py
@@ -44,10 +44,11 @@ def shrink(tensor: Tensor, arg: tuple[tuple[shape_int, shape_int] | None, ...]) 
 
 
 def pad(tensor: Tensor, arg: tuple[tuple[int, int] | None, ...], value: float) -> Tensor:
+    from edugrad.tensor import Tensor
     if all(x is None or x == (0, 0) for x in arg):
         return tensor
     ret = function.Pad.apply(tensor, arg=(narg := tuple(x if x is not None else (0, 0) for x in arg)))
-    return ret if 0 == value else ret + function.Pad.apply("Tensor".ones_like(tensor), arg=narg).where(0, value)
+    return ret if 0 == value else ret + function.Pad.apply(Tensor.ones_like(tensor), arg=narg).where(0, value)
 
 
 # (padding_left, padding_right, padding_top, padding_bottom)

--- a/edugrad/data.py
+++ b/edugrad/data.py
@@ -13,7 +13,8 @@ If you would like to use another backend for storing and computing data, it woul
 from typing import Tuple
 import numpy as np
 from edugrad.ops import UnaryOps, BinaryOps, TernaryOps, ReduceOps, LoadOps  # consider reading the docs there
-from edugrad.helpers import DType, dtypes, DEBUG
+from edugrad.helpers import DEBUG
+from edugrad.dtypes import DType, dtypes
 
 
 class TensorData:

--- a/edugrad/data.py
+++ b/edugrad/data.py
@@ -77,22 +77,22 @@ class TensorData:
     def elementwise(self, op, *srcs: "TensorData"):
         """Perform a unary, binary, or ternary elementwise operation on the data."""
         unary_ops = {
-            UnaryOps.NEG: np.negative,
-            UnaryOps.EXP2: np.exp2,
-            UnaryOps.LOG2: np.log2,
-            UnaryOps.SIN: np.sin,
-            UnaryOps.SQRT: np.sqrt,
-        }
+                UnaryOps.NEG: lambda x: np.negative(x).astype(dtypes.only_float.np),
+                UnaryOps.EXP2: lambda x: np.exp2(x).astype(dtypes.only_float.np),
+                UnaryOps.LOG2: lambda x: np.log2(x).astype(dtypes.only_float.np),
+                UnaryOps.SIN: lambda x: np.sin(x).astype(dtypes.only_float.np),
+                UnaryOps.SQRT: lambda x: np.sqrt(x).astype(dtypes.only_float.np),
+            }
         binary_ops = {
-            BinaryOps.ADD: np.add,
-            BinaryOps.SUB: np.subtract,
-            BinaryOps.MUL: np.multiply,
-            BinaryOps.DIV: np.divide,
-            BinaryOps.MAX: np.maximum,
-            BinaryOps.CMPLT: np.less,
+            BinaryOps.ADD: lambda x, y: np.add(x, y).astype(dtypes.only_float.np),
+            BinaryOps.SUB: lambda x, y: np.subtract(x, y).astype(dtypes.only_float.np),
+            BinaryOps.MUL: lambda x, y: np.multiply(x, y).astype(dtypes.only_float.np),
+            BinaryOps.DIV: lambda x, y: np.divide(x, y).astype(dtypes.only_float.np),
+            BinaryOps.MAX: lambda x, y: np.maximum(x, y).astype(dtypes.only_float.np),
+            BinaryOps.CMPLT: lambda x, y: np.less(x, y).astype(np.bool_),
         }
         ternary_ops = {
-            TernaryOps.WHERE: np.where,
+            TernaryOps.WHERE: lambda x, y, z: np.where(x, y, z).astype(dtypes.only_float.np),
         }
 
         if op in unary_ops:

--- a/edugrad/data.py
+++ b/edugrad/data.py
@@ -1,7 +1,10 @@
 """Defines the TensorData class, a container for tensor data (tensor.Tensor.data), represented as numpy arrays.
 
 It facilitates direct manipulation of tensor data through a range of basic operation ("low-level ops"). These operations
-are building blocks for defining forward and backward passes of differentiable function.Functions. ("mid-level ops")
+are building blocks for defining forward and backward passes of differentiable function.Functions. ("mid-level ops").
+
+For simplicity and to ensure that compatible dtypes operate with each other, we enforce two of the three supported
+dtypes (bool and float32) with a typecast in each elementwise operation.
 
 The ops are executed immediately on the CPU using numpy. This approach contrasts with deferred computation models that
 analyze subsequent delayed operations in order to find an optimized equivalent final optimization at the point where

--- a/edugrad/dtypes.py
+++ b/edugrad/dtypes.py
@@ -63,5 +63,5 @@ class dtypes:
 DTYPES_DICT = {
     k: v
     for k, v in dtypes.__dict__.items()
-    if not k.startswith("__") and not callable(v) and not v.__class__ == staticmethod
+    if not k.startswith("__")  and not k.startswith("only") and not callable(v) and not v.__class__ == staticmethod
 }

--- a/edugrad/dtypes.py
+++ b/edugrad/dtypes.py
@@ -52,8 +52,8 @@ class dtypes:
 
     # Definition of various data types
     bool: Final[DType] = DType(0, 1, "bool", np.bool_)
-    float32: Final[DType] = DType(10, 4, "float", np.float32)
-    int32: Final[DType] = DType(5, 4, "int", np.int32)
+    float32: Final[DType] = DType(2, 4, "float", np.float32)
+    int32: Final[DType] = DType(1, 4, "int", np.int32)
  
     only_float: ClassVar[DType] = float32
     only_int: ClassVar[DType] = int32

--- a/edugrad/dtypes.py
+++ b/edugrad/dtypes.py
@@ -1,0 +1,91 @@
+from typing import ClassVar, Dict, Optional, Final
+import numpy as np
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, order=True)
+class DType:
+    """Data type class for managing different data types."""
+
+    priority: int  # Priority for upcasting
+    itemsize: int  # Size of the data type in bytes
+    name: str  # Name of the data type
+    np: Optional[type]  # Corresponding numpy data type
+    sz: int = 1  # Size factor
+
+    def __repr__(self):
+        return f"dtypes.{self.name}"
+
+
+class dtypes:
+    """Container for different data types and utility methods.
+    We need this because some layer operation might use different trade-offs between precision and efficiency. In such
+    cases, we have to translate b/w dtypes.
+    """
+
+    @staticmethod
+    def is_int(x: DType) -> bool:
+        """Check if a data type is an integer type."""
+        return x in (
+            dtypes.int8,
+            dtypes.int16,
+            dtypes.int32,
+            dtypes.int64,
+            dtypes.uint8,
+            dtypes.uint16,
+            dtypes.uint32,
+            dtypes.uint64,
+        )
+
+    @staticmethod
+    def is_float(x: DType) -> bool:
+        """Check if a data type is a float type."""
+        return x in (dtypes.float16, dtypes.float32, dtypes.float64)
+
+    @staticmethod
+    def is_unsigned(x: DType) -> bool:
+        """Check if a data type is an unsigned type."""
+        return x in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
+
+    @staticmethod
+    def from_np(x) -> DType:
+        """Convert a numpy data type to a DType."""
+        return DTYPES_DICT[np.dtype(x).name]
+
+    @staticmethod
+    def fields() -> Dict[str, DType]:
+        return DTYPES_DICT
+
+    @staticmethod  # NOTE: isinstance(True, int) is True in python
+    def from_py(x) -> DType:
+        return (
+            dtypes.default_float if isinstance(x, float) else dtypes.bool if isinstance(x, bool) else dtypes.default_int
+        )
+
+    # Definition of various data types
+    bool: Final[DType] = DType(0, 1, "bool", np.bool_)
+    float16: Final[DType] = DType(9, 2, "half", np.float16)
+    half = float16
+    float32: Final[DType] = DType(10, 4, "float", np.float32)
+    float = float32
+    float64: Final[DType] = DType(11, 8, "double", np.float64)
+    double = float64
+    int8: Final[DType] = DType(1, 1, "char", np.int8)
+    int16: Final[DType] = DType(3, 2, "short", np.int16)
+    int32: Final[DType] = DType(5, 4, "int", np.int32)
+    int64: Final[DType] = DType(7, 8, "long", np.int64)
+    uint8: Final[DType] = DType(2, 1, "unsigned char", np.uint8)
+    uint16: Final[DType] = DType(4, 2, "unsigned short", np.uint16)
+    uint32: Final[DType] = DType(6, 4, "unsigned int", np.uint32)
+    uint64: Final[DType] = DType(8, 8, "unsigned long", np.uint64)
+
+    default_float: ClassVar[DType] = float32
+    default_int: ClassVar[DType] = int32
+
+
+# Dictionary mapping data type names to DType objects
+DTYPES_DICT = {
+    k: v
+    for k, v in dtypes.__dict__.items()
+    if not k.startswith("__") and not callable(v) and not v.__class__ == staticmethod
+}

--- a/edugrad/dtypes.py
+++ b/edugrad/dtypes.py
@@ -27,25 +27,13 @@ class dtypes:
     def is_int(x: DType) -> bool:
         """Check if a data type is an integer type."""
         return x in (
-            dtypes.int8,
-            dtypes.int16,
             dtypes.int32,
-            dtypes.int64,
-            dtypes.uint8,
-            dtypes.uint16,
-            dtypes.uint32,
-            dtypes.uint64,
         )
 
     @staticmethod
     def is_float(x: DType) -> bool:
         """Check if a data type is a float type."""
-        return x in (dtypes.float16, dtypes.float32, dtypes.float64)
-
-    @staticmethod
-    def is_unsigned(x: DType) -> bool:
-        """Check if a data type is an unsigned type."""
-        return x in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
+        return x in (dtypes.float32)
 
     @staticmethod
     def from_np(x) -> DType:
@@ -59,28 +47,16 @@ class dtypes:
     @staticmethod  # NOTE: isinstance(True, int) is True in python
     def from_py(x) -> DType:
         return (
-            dtypes.default_float if isinstance(x, float) else dtypes.bool if isinstance(x, bool) else dtypes.default_int
+            dtypes.only_float if isinstance(x, float) else dtypes.bool if isinstance(x, bool) else dtypes.only_int
         )
 
     # Definition of various data types
     bool: Final[DType] = DType(0, 1, "bool", np.bool_)
-    float16: Final[DType] = DType(9, 2, "half", np.float16)
-    half = float16
     float32: Final[DType] = DType(10, 4, "float", np.float32)
-    float = float32
-    float64: Final[DType] = DType(11, 8, "double", np.float64)
-    double = float64
-    int8: Final[DType] = DType(1, 1, "char", np.int8)
-    int16: Final[DType] = DType(3, 2, "short", np.int16)
     int32: Final[DType] = DType(5, 4, "int", np.int32)
-    int64: Final[DType] = DType(7, 8, "long", np.int64)
-    uint8: Final[DType] = DType(2, 1, "unsigned char", np.uint8)
-    uint16: Final[DType] = DType(4, 2, "unsigned short", np.uint16)
-    uint32: Final[DType] = DType(6, 4, "unsigned int", np.uint32)
-    uint64: Final[DType] = DType(8, 8, "unsigned long", np.uint64)
-
-    default_float: ClassVar[DType] = float32
-    default_int: ClassVar[DType] = int32
+ 
+    only_float: ClassVar[DType] = float32
+    only_int: ClassVar[DType] = int32
 
 
 # Dictionary mapping data type names to DType objects

--- a/edugrad/function.py
+++ b/edugrad/function.py
@@ -356,3 +356,12 @@ class Shrink(Function):
         ), "symbolic shrink does not support backward"
         # need this cast because mypy cannot narrow the type even with assert
         return grad_output.pad(cast(Tuple[Tuple[int, int], ...], self.narg))
+
+
+class Flip(Function):
+    def forward(self, x: TensorData, axis: Tuple[int, ...]) -> TensorData:
+        self.arg = tuple([-1 if i in set(axis) else 1 for i in range(len(x.shape))])
+        return x.stride(self.arg)
+
+    def backward(self, grad_output: TensorData) -> TensorData:
+        return grad_output.stride(self.arg)

--- a/edugrad/function.py
+++ b/edugrad/function.py
@@ -11,7 +11,8 @@ All these functions are applied to and return TensorData objects that can be cal
 """
 import math
 from typing import Tuple, Optional, cast
-from edugrad.helpers import argsort, DType, shape_int
+from edugrad.dtypes import DType
+from edugrad.helpers import argsort, shape_int
 from edugrad.ops import UnaryOps, BinaryOps, TernaryOps, ReduceOps
 from edugrad.data import TensorData
 

--- a/edugrad/helpers.py
+++ b/edugrad/helpers.py
@@ -1,7 +1,6 @@
-from typing import Union, Tuple, Iterator, Optional, Final, Any
+from typing import Union, Tuple, Iterator, Any
 import os
 import functools
-import numpy as np
 from math import prod  # noqa: F401 # pylint:disable=unused-import
 from dataclasses import dataclass
 
@@ -55,83 +54,3 @@ def getenv(key, default=0):
 
 # Global flags for debugging and continuous integration
 DEBUG = getenv("DEBUG")
-
-
-@dataclass(frozen=True, order=True)
-class DType:
-    """Data type class for managing different data types."""
-
-    priority: int  # Priority for upcasting
-    itemsize: int  # Size of the data type in bytes
-    name: str  # Name of the data type
-    np: Optional[type]  # Corresponding numpy data type
-    sz: int = 1  # Size factor
-
-    def __repr__(self):
-        return f"dtypes.{self.name}"
-
-
-class dtypes:
-    """Container for different data types and utility methods.
-
-    We need this because some layer operation might use different trade-offs between precision and efficiency. In such
-    cases, we have to translate b/w dtypes.
-
-    """
-
-    @staticmethod
-    def is_int(x: DType) -> bool:
-        """Check if a data type is an integer type."""
-        return x in (
-            dtypes.int8,
-            dtypes.int16,
-            dtypes.int32,
-            dtypes.int64,
-            dtypes.uint8,
-            dtypes.uint16,
-            dtypes.uint32,
-            dtypes.uint64,
-        )
-
-    @staticmethod
-    def is_float(x: DType) -> bool:
-        """Check if a data type is a float type."""
-        return x in (dtypes.float16, dtypes.float32, dtypes.float64)
-
-    @staticmethod
-    def is_unsigned(x: DType) -> bool:
-        """Check if a data type is an unsigned type."""
-        return x in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
-
-    @staticmethod
-    def from_np(x) -> DType:
-        """Convert a numpy data type to a DType."""
-        return DTYPES_DICT[np.dtype(x).name]
-
-    # Definition of various data types
-    bool: Final[DType] = DType(0, 1, "bool", np.bool_)
-    float16: Final[DType] = DType(9, 2, "half", np.float16)
-    half = float16
-    float32: Final[DType] = DType(10, 4, "float", np.float32)
-    float = float32
-    float64: Final[DType] = DType(11, 8, "double", np.float64)
-    double = float64
-    int8: Final[DType] = DType(1, 1, "char", np.int8)
-    int16: Final[DType] = DType(3, 2, "short", np.int16)
-    int32: Final[DType] = DType(5, 4, "int", np.int32)
-    int64: Final[DType] = DType(7, 8, "long", np.int64)
-    uint8: Final[DType] = DType(2, 1, "unsigned char", np.uint8)
-    uint16: Final[DType] = DType(4, 2, "unsigned short", np.uint16)
-    uint32: Final[DType] = DType(6, 4, "unsigned int", np.uint32)
-    uint64: Final[DType] = DType(8, 8, "unsigned long", np.uint64)
-
-    # Note: bfloat16 isn't supported in numpy
-    bfloat16: Final[DType] = DType(9, 2, "__bf16", None)
-
-
-# Dictionary mapping data type names to DType objects
-DTYPES_DICT = {
-    k: v
-    for k, v in dtypes.__dict__.items()
-    if not k.startswith("__") and not callable(v) and not v.__class__ == staticmethod
-}

--- a/edugrad/helpers.py
+++ b/edugrad/helpers.py
@@ -27,6 +27,12 @@ def flatten(list_: Iterator):
     return [item for sublist in list_ for item in sublist]
 
 
+def fully_flatten(l):
+    return [
+        item for sublist in l for item in (fully_flatten(sublist) if isinstance(sublist, (tuple, list)) else [sublist])
+    ]
+
+
 def argsort(x):
     """Return the indices that would sort an array.
 

--- a/edugrad/tensor.py
+++ b/edugrad/tensor.py
@@ -13,7 +13,8 @@ import time
 from typing import ClassVar, Sequence, Any
 import numpy as np
 
-from edugrad.helpers import getenv, DEBUG, DType, dtypes, prod, all_int, round_up, shape_int
+from edugrad.dtypes import DType, dtypes
+from edugrad.helpers import getenv, DEBUG, prod, all_int, round_up, shape_int
 from edugrad.data import TensorData
 from edugrad.ops import LoadOps
 from edugrad.function import Function

--- a/edugrad/tensor.py
+++ b/edugrad/tensor.py
@@ -15,7 +15,7 @@ from typing import ClassVar, Sequence, Any, Type
 
 import numpy as np
 
-from edugrad.dtypes import DType, dtypes
+from edugrad.dtypes import DType, dtypes, DTYPES_DICT
 from edugrad.helpers import getenv, DEBUG, prod, all_int, round_up, shape_int
 from edugrad.data import TensorData
 from edugrad.ops import LoadOps
@@ -60,7 +60,7 @@ class Tensor:
         dtype: DType | None = None,
         requires_grad: bool | None = None,
     ):
-        assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
+        assert dtype is None or isinstance(dtype, DType), f"Invalid dtype {dtype}. edugrad only supports {list(DTYPES_DICT.keys())}"
 
         # tensors have gradients, buffers do not
         self.grad: Tensor | None = None

--- a/edugrad/tensor.py
+++ b/edugrad/tensor.py
@@ -74,7 +74,7 @@ class Tensor:
 
         # --------------------------------------------------------------------------------------------------------------
         # Handles Tensor(x) for x with different data types.
-        # We cast x = list(y) up to float32 (default_type) for every type that y can have
+        # We cast x = list(y) up to float32 (default_type) for every type that y can have if no other type is provided
 
         if isinstance(data, TensorData):
             assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"

--- a/edugrad/tensor.py
+++ b/edugrad/tensor.py
@@ -28,7 +28,7 @@ from edugrad._tensor.tensor_create import full, zeros, ones, arange, eye, full_l
 from edugrad._tensor.tensor_combine_segment import cat, stack, repeat, chunk
 from edugrad._tensor.tensor_reshape import reshape, expand, permute, flip, shrink, pad, pad2d, transpose, _flatten, squeeze, unsqueeze
 from edugrad._tensor.tensor_nn import _pool, avg_pool2d, max_pool2d, conv2d, linear, binary_crossentropy, binary_crossentropy_logits, sparse_categorical_crossentropy
-from edugrad._tensor.tensor_index_slice import __getitem__, __setitem__, slice, gather
+from edugrad._tensor.tensor_index_slice import __getitem__, __setitem__, tslice, gather
 from edugrad._tensor.tensor_broadcasted_binary_mlops import _broadcasted, _to_float, add, sub, mul, div, pow, matmul, maximum, minimum, where
 from edugrad._tensor.tensor_reduce import _reduce, tsum, tmax, tmin, mean, std, _softmax, softmax, log_softmax, argmax, argmin
 # fmt: on
@@ -221,7 +221,7 @@ class Tensor:
     def expand(self, shape, *args) -> Tensor: return expand(self, shape, *args)
     def permute(self, order, *args) -> Tensor: return permute(self, order, *args)
     def flip(self, axis, *args) -> Tensor: return flip(self, axis, *args)
-    def pad(self, arg:tuple[tuple[int, int] | None, ...], value:float=0.0) -> Tensor: pad(self, arg, value)
+    def pad(self, arg:tuple[tuple[int, int] | None, ...], value:float=0.0) -> Tensor: return pad(self, arg, value)
     # (padding_left, padding_right, padding_top, padding_bottom)
     def pad2d(self, padding:list[int] | tuple[int, ...], value:float=0) -> Tensor: return pad2d(self, padding, value)
     def shrink(self, arg:tuple[tuple[shape_int, shape_int] | None, ...]) -> Tensor: return shrink(self, arg)
@@ -244,7 +244,7 @@ class Tensor:
 
     # NOTE: using slice is discouraged and things should migrate to pad and shrink
     def slice(self, arg:Sequence[tuple[int, shape_int] | None], value:float=0) -> Tensor:
-        return slice(self, arg, value)
+        return tslice(self, arg, value)
 
     def gather(self: Tensor, idx: Tensor, dim: int) -> Tensor: return gather(self, idx, dim)
 

--- a/edugrad/tensor.py
+++ b/edugrad/tensor.py
@@ -11,7 +11,7 @@ The high-level ops support many things that you could expect from a tensor libra
 from __future__ import annotations
 import time
 import math
-from typing import ClassVar, Sequence, Any
+from typing import ClassVar, Sequence, Any, Type
 
 import numpy as np
 
@@ -74,7 +74,7 @@ class Tensor:
 
         # --------------------------------------------------------------------------------------------------------------
         # Handles Tensor(x) for x with different data types.
-        # We cast x = list(y) up to float32 for every case
+        # We cast x = list(y) up to float32 (default_type) for every type that y can have
 
         if isinstance(data, TensorData):
             assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
@@ -87,9 +87,6 @@ class Tensor:
     
         elif data is None:
             data = TensorData.loadop(LoadOps.EMPTY, (0,), dtype or dtypes.only_float)
-        
-        elif isinstance(data, bytes):
-            data = TensorData(np.frombuffer(data, np.uint8))
 
         elif isinstance(data, np.ndarray):
             assert dtype is None or dtype.np is not None, f"{dtype} doesn't have a numpy dtype"

--- a/edugrad/tensor.py
+++ b/edugrad/tensor.py
@@ -86,7 +86,7 @@ class Tensor:
             data = TensorData(np.array(data, dtype=(dtype or Tensor.default_type).np))
     
         elif data is None:
-            data = TensorData.loadop(LoadOps.EMPTY, (0,), dtype or dtypes.default_float)
+            data = TensorData.loadop(LoadOps.EMPTY, (0,), dtype or dtypes.only_float)
         
         elif isinstance(data, bytes):
             data = TensorData(np.frombuffer(data, np.uint8))

--- a/edugrad/tensor.py
+++ b/edugrad/tensor.py
@@ -10,7 +10,9 @@ The high-level ops support many things that you could expect from a tensor libra
 # inspired by https://github.com/karpathy/micrograd/blob/master/micrograd/engine.py
 from __future__ import annotations
 import time
+import math
 from typing import ClassVar, Sequence, Any
+
 import numpy as np
 
 from edugrad.dtypes import DType, dtypes
@@ -251,8 +253,7 @@ class Tensor:
     # ------------------------------------------------------------------------------------------------------------------
     # tensor_combine_segment.py
 
-    def cat(self, *args, dim=0) -> Tensor: return cat(self, *args, dim)
-    @staticmethod
+    def cat(self, *args, dim=0) -> Tensor: return cat(self, *args, dim=dim)    @staticmethod
     def stack(tensors, dim=0) -> Tensor: stack(tensors, dim)
     def repeat(self, repeats) -> Tensor: repeat(self, repeats)
     def chunk(self, num:int, dim:int=0) -> list[Tensor]: chunk(self, num, dim)
@@ -323,11 +324,13 @@ class Tensor:
     def relu(self): return function.Relu.apply(self)
     def sigmoid(self): return function.Sigmoid.apply(self)
     def sqrt(self): return function.Sqrt.apply(self)
+    def sin(self): return function.Sin.apply(self)
+    def cos(self): return ((math.pi/2)-self).sin()
 
     # math functions (unary) skipped
 
     # activation functions (unary) skipped
-
+    def elu(self, alpha=1.0): return self.relu() - alpha*(1-self.exp()).relu()
     # ------------------------------------------------------------------------------------------------------------------
     # tensor_bradcasted_binary_mlops.py
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,3 +11,4 @@ dependencies:
 
   # Tests
   - pytest
+  - pytorch

--- a/tests/gradcheck.py
+++ b/tests/gradcheck.py
@@ -1,0 +1,54 @@
+import numpy as np
+from edugrad.tensor import Tensor
+
+
+def mask_like(like, mask_inx, mask_value=1.0):
+    mask = np.zeros_like(like).reshape(-1)
+    mask[mask_inx] = mask_value
+    return mask.reshape(like.shape)
+
+
+def jacobian(func, input):
+    output = func(input)
+
+    ji = input.numpy().reshape(-1).shape[-1]
+    jo = output.numpy().reshape(-1).shape[-1]
+    J = np.zeros((jo, ji), dtype=np.float32)
+
+    for o in range(jo):
+        input.grad = None
+        output = func(input)
+
+        # tinygrad doesn't support slicing, tiny-hack to select
+        # the needed scalar an backpropagate only through it
+        o_scalar = Tensor(mask_like(output.numpy(), o, 1.0)).mul(output).sum()
+        o_scalar.backward()
+
+        for i, grad in enumerate(input.grad.numpy().reshape(-1)):
+            J[o, i] = grad
+    return J
+
+
+def numerical_jacobian(func, input, eps=1e-3):
+    output = func(input)
+
+    ji = input.numpy().reshape(-1).shape[-1]
+    jo = output.numpy().reshape(-1).shape[-1]
+    NJ = np.zeros((jo, ji), dtype=np.float32)
+
+    for i in range(ji):
+        eps_perturb = mask_like(input.numpy(), i, mask_value=eps)
+
+        output_perturb_add = func(Tensor(input.numpy() + eps_perturb)).numpy().reshape(-1)
+        output_perturb_sub = func(Tensor(input.numpy() - eps_perturb)).numpy().reshape(-1)
+
+        grad_approx = ((output_perturb_add) - (output_perturb_sub)) / (2 * eps)
+
+        NJ[:, i] = grad_approx
+    return NJ
+
+
+def gradcheck(func, input, eps=1e-3, atol=1e-3, rtol=1e-3):
+    NJ = numerical_jacobian(func, input, eps)
+    J = jacobian(func, input)
+    return np.allclose(J, NJ, atol=atol, rtol=rtol)

--- a/tests/gradcheck.py
+++ b/tests/gradcheck.py
@@ -19,7 +19,7 @@ def jacobian(func, input):
         input.grad = None
         output = func(input)
 
-        # tinygrad doesn't support slicing, tiny-hack to select
+        # edugrad doesn't support slicing, tiny-hack to select
         # the needed scalar an backpropagate only through it
         o_scalar = Tensor(mask_like(output.numpy(), o, 1.0)).mul(output).sum()
         o_scalar.backward()

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -12,9 +12,9 @@ W_init = np.random.randn(3, 3).astype(np.float32)
 m_init = np.random.randn(1, 3).astype(np.float32)
 
 
-class TestTinygrad(unittest.TestCase):
+class TestEdugrad(unittest.TestCase):
     def test_backward_pass(self):
-        def test_tinygrad():
+        def test_edugrad():
             x = Tensor(x_init, requires_grad=True)
             W = Tensor(W_init, requires_grad=True)
             m = Tensor(m_init)
@@ -34,11 +34,11 @@ class TestTinygrad(unittest.TestCase):
             out.backward()
             return out.detach().numpy(), x.grad, W.grad
 
-        for x, y in zip(test_tinygrad(), test_pytorch()):
+        for x, y in zip(test_edugrad(), test_pytorch()):
             np.testing.assert_allclose(x, y, atol=1e-5)
 
     def test_backward_pass_diamond_model(self):
-        def test_tinygrad():
+        def test_edugrad():
             u = Tensor(U_init, requires_grad=True)
             v = Tensor(V_init, requires_grad=True)
             w = Tensor(W_init, requires_grad=True)
@@ -62,7 +62,7 @@ class TestTinygrad(unittest.TestCase):
             out.backward()
             return out.detach().numpy(), u.grad, v.grad, w.grad
 
-        for x, y in zip(test_tinygrad(), test_pytorch()):
+        for x, y in zip(test_edugrad(), test_pytorch()):
             np.testing.assert_allclose(x, y, atol=1e-5)
 
     def test_nograd(self):
@@ -92,14 +92,14 @@ class TestTinygrad(unittest.TestCase):
 
         PJ = torch.autograd.functional.jacobian(torch_func, torch_x).squeeze().numpy()
 
-        tiny_x = Tensor(x, requires_grad=True)
-        tiny_W = Tensor(W, requires_grad=True)
+        edugrad_x = Tensor(x, requires_grad=True)
+        edugrad_W = Tensor(W, requires_grad=True)
 
-        def tiny_func(x):
-            return x.dot(tiny_W).relu().log_softmax()
+        def func(x):
+            return x.dot(edugrad_W).relu().log_softmax()
 
-        J = jacobian(tiny_func, tiny_x)
-        NJ = numerical_jacobian(tiny_func, tiny_x)
+        J = jacobian(func, edugrad_x)
+        NJ = numerical_jacobian(func, edugrad_x)
 
         np.testing.assert_allclose(PJ, J, atol=1e-5)
         np.testing.assert_allclose(PJ, NJ, atol=1e-3)
@@ -108,16 +108,16 @@ class TestTinygrad(unittest.TestCase):
         W = np.random.RandomState(1337).random((10, 5)).astype(np.float32)
         x = np.random.RandomState(7331).random((1, 10)).astype(np.float32)
 
-        tiny_x = Tensor(x, requires_grad=True)
-        tiny_W = Tensor(W, requires_grad=True)
+        edugrad_x = Tensor(x, requires_grad=True)
+        edugrad_W = Tensor(W, requires_grad=True)
 
-        def tiny_func(x):
-            return x.dot(tiny_W).relu().log_softmax()
+        def func(x):
+            return x.dot(edugrad_W).relu().log_softmax()
 
-        self.assertTrue(gradcheck(tiny_func, tiny_x, eps=1e-3))
+        self.assertTrue(gradcheck(func, edugrad_x, eps=1e-3))
 
         # coarse approx. since a "big" eps and the non-linearities of the model
-        self.assertFalse(gradcheck(tiny_func, tiny_x, eps=1e-5))
+        self.assertFalse(gradcheck(func, edugrad_x, eps=1e-5))
 
 
     def test_deepwalk_ctx_check(self):

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -1,0 +1,128 @@
+import numpy as np
+import torch
+import unittest
+from edugrad import Tensor
+
+from tests.gradcheck import numerical_jacobian, jacobian, gradcheck
+
+x_init = np.random.randn(1, 3).astype(np.float32)
+U_init = np.random.randn(3, 3).astype(np.float32)
+V_init = np.random.randn(3, 3).astype(np.float32)
+W_init = np.random.randn(3, 3).astype(np.float32)
+m_init = np.random.randn(1, 3).astype(np.float32)
+
+
+class TestTinygrad(unittest.TestCase):
+    def test_backward_pass(self):
+        def test_tinygrad():
+            x = Tensor(x_init, requires_grad=True)
+            W = Tensor(W_init, requires_grad=True)
+            m = Tensor(m_init)
+            out = x.dot(W).relu()
+            out = out.log_softmax()
+            out = out.mul(m).add(m).sum()
+            out.backward()
+            return out.numpy(), x.grad.numpy(), W.grad.numpy()
+
+        def test_pytorch():
+            x = torch.tensor(x_init, requires_grad=True)
+            W = torch.tensor(W_init, requires_grad=True)
+            m = torch.tensor(m_init)
+            out = x.matmul(W).relu()
+            out = torch.nn.functional.log_softmax(out, dim=1)
+            out = out.mul(m).add(m).sum()
+            out.backward()
+            return out.detach().numpy(), x.grad, W.grad
+
+        for x, y in zip(test_tinygrad(), test_pytorch()):
+            np.testing.assert_allclose(x, y, atol=1e-5)
+
+    def test_backward_pass_diamond_model(self):
+        def test_tinygrad():
+            u = Tensor(U_init, requires_grad=True)
+            v = Tensor(V_init, requires_grad=True)
+            w = Tensor(W_init, requires_grad=True)
+            x = u.mul(v).relu()
+            y = u.mul(w).relu()
+            out = x.add(y).mul(y).relu()
+            out = out.log_softmax()
+            out = out.sum()
+            out.backward()
+            return out.numpy(), u.grad.numpy(), v.grad.numpy(), w.grad.numpy()
+
+        def test_pytorch():
+            u = torch.tensor(U_init, requires_grad=True)
+            v = torch.tensor(V_init, requires_grad=True)
+            w = torch.tensor(W_init, requires_grad=True)
+            x = u.mul(v).relu()
+            y = u.mul(w).relu()
+            out = x.add(y).mul(y).relu()
+            out = torch.nn.functional.log_softmax(out, dim=1)
+            out = out.sum()
+            out.backward()
+            return out.detach().numpy(), u.grad, v.grad, w.grad
+
+        for x, y in zip(test_tinygrad(), test_pytorch()):
+            np.testing.assert_allclose(x, y, atol=1e-5)
+
+    def test_nograd(self):
+        x = Tensor(x_init, requires_grad=False)
+        m = Tensor(m_init, requires_grad=False)
+        W = Tensor(W_init, requires_grad=True)
+        tmp = x.mul(m)
+        mm = tmp.matmul(W)
+        out = mm.relu()
+        out = out.sum()
+        out.backward()
+        assert x.grad is None
+        assert m.grad is None
+        assert tmp.grad is None
+        assert mm.grad is not None
+        assert W.grad is not None
+
+    def test_jacobian(self):
+        W = np.random.RandomState(42069).random((10, 5)).astype(np.float32)
+        x = np.random.RandomState(69420).random((1, 10)).astype(np.float32)
+
+        torch_x = torch.tensor(x, requires_grad=True)
+        torch_W = torch.tensor(W, requires_grad=True)
+
+        def torch_func(x):
+            return torch.nn.functional.log_softmax(x.matmul(torch_W).relu(), dim=1)
+
+        PJ = torch.autograd.functional.jacobian(torch_func, torch_x).squeeze().numpy()
+
+        tiny_x = Tensor(x, requires_grad=True)
+        tiny_W = Tensor(W, requires_grad=True)
+
+        def tiny_func(x):
+            return x.dot(tiny_W).relu().log_softmax()
+
+        J = jacobian(tiny_func, tiny_x)
+        NJ = numerical_jacobian(tiny_func, tiny_x)
+
+        np.testing.assert_allclose(PJ, J, atol=1e-5)
+        np.testing.assert_allclose(PJ, NJ, atol=1e-3)
+
+    def test_gradcheck(self):
+        W = np.random.RandomState(1337).random((10, 5)).astype(np.float32)
+        x = np.random.RandomState(7331).random((1, 10)).astype(np.float32)
+
+        tiny_x = Tensor(x, requires_grad=True)
+        tiny_W = Tensor(W, requires_grad=True)
+
+        def tiny_func(x):
+            return x.dot(tiny_W).relu().log_softmax()
+
+        self.assertTrue(gradcheck(tiny_func, tiny_x, eps=1e-3))
+
+        # coarse approx. since a "big" eps and the non-linearities of the model
+        self.assertFalse(gradcheck(tiny_func, tiny_x, eps=1e-5))
+
+
+    def test_deepwalk_ctx_check(self):
+        layer = Tensor.uniform(1, 1, requires_grad=True)
+        x = Tensor.randn(1, 1, 1)
+        x.dot(layer).mean().backward()
+        x = Tensor.randn(1, 1, 1)
+        x.dot(layer).mean().backward()

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,2 +1,0 @@
-def test_dummy():
-    assert True is True

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,7 +2,7 @@ import unittest
 from edugrad import Tensor
 
 
-class TestTinygrad(unittest.TestCase):
+class TestEdugrad(unittest.TestCase):
 
     def test_argfix(self):
         self.assertEqual(Tensor.zeros().shape, ())

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,33 @@
+import unittest
+from edugrad import Tensor
+
+
+class TestTinygrad(unittest.TestCase):
+
+    def test_argfix(self):
+        self.assertEqual(Tensor.zeros().shape, ())
+        self.assertEqual(Tensor.ones().shape, ())
+
+        self.assertEqual(Tensor.zeros([]).shape, ())
+        self.assertEqual(Tensor.ones([]).shape, ())
+
+        self.assertEqual(Tensor.zeros(tuple()).shape, ())
+        self.assertEqual(Tensor.ones(tuple()).shape, ())
+
+        self.assertEqual(Tensor.zeros(1).shape, (1,))
+        self.assertEqual(Tensor.ones(1).shape, (1,))
+
+        self.assertEqual(Tensor.zeros(1, 10, 20).shape, (1, 10, 20))
+        self.assertEqual(Tensor.ones(1, 10, 20).shape, (1, 10, 20))
+
+        self.assertEqual(Tensor.zeros([1]).shape, (1,))
+        self.assertEqual(Tensor.ones([1]).shape, (1,))
+
+        self.assertEqual(Tensor.zeros([10, 20, 40]).shape, (10, 20, 40))
+        self.assertEqual(Tensor.ones([10, 20, 40]).shape, (10, 20, 40))
+
+        self.assertEqual(Tensor.rand(1, 10, 20).shape, (1, 10, 20))
+        self.assertEqual(Tensor.rand((10, 20, 40)).shape, (10, 20, 40))
+
+        self.assertEqual(Tensor.empty(1, 10, 20).shape, (1, 10, 20))
+        self.assertEqual(Tensor.empty((10, 20, 40)).shape, (10, 20, 40))

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -1,8 +1,5 @@
-import sys
-print(sys.path)
-
-import pytest
 from applications.learn_mnist import train_and_evaluate_mnist
+
 
 def test_mnist_accuracy():
     test_accuracy = train_and_evaluate_mnist()

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -1,0 +1,9 @@
+import sys
+print(sys.path)
+
+import pytest
+from applications.learn_mnist import train_and_evaluate_mnist
+
+def test_mnist_accuracy():
+    test_accuracy = train_and_evaluate_mnist()
+    assert test_accuracy > 0.93, f"Test accuracy too low: {test_accuracy}"

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -169,7 +169,7 @@ class TestTinygrad(unittest.TestCase):
         a = Tensor([1, 2, 3])
         b = Tensor.zeros_like(a, dtype=dtypes.int8)
         assert (
-            a.dtype == dtypes.default_int and b.dtype == dtypes.int8
+            a.dtype == dtypes.only_int and b.dtype == dtypes.int8
         ), "a.dtype should be int and b.dtype should be char"
         assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
 
@@ -184,7 +184,7 @@ class TestTinygrad(unittest.TestCase):
         a = Tensor([1, 2, 3])
         b = Tensor.ones_like(a, dtype=dtypes.int8)
         assert (
-            a.dtype == dtypes.default_int and b.dtype == dtypes.int8
+            a.dtype == dtypes.only_int and b.dtype == dtypes.int8
         ), "a.dtype should be int and b.dtype should be char"
         assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
 
@@ -260,7 +260,7 @@ class TestTinygrad(unittest.TestCase):
         for arr in ([1], [[[1]]], [[1, 1], [1, 1]], [[[1, 1], [1, 1]], [[1, 1], [1, 1]]]):
             x = Tensor(arr)
             have = x.dtype
-            assert Tensor(arr).dtype == dtypes.default_int
+            assert Tensor(arr).dtype == dtypes.only_int
             assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32
             assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64
 
@@ -277,13 +277,13 @@ class TestTinygrad(unittest.TestCase):
         # empty tensor defaults
         for arr in ([], [[[]]], [[], []]):
             t = Tensor(arr)
-            assert t.dtype == dtypes.default_float
+            assert t.dtype == dtypes.only_float
             np.testing.assert_allclose(t.numpy(), np.array(arr))
 
         # mixture of bool and int
         for arr in ([True, 3], [[True], [3]], [[[True]], [[3]]], [[True, 3], [3, True]]):
             t = Tensor(arr)
-            assert t.dtype == dtypes.default_int
+            assert t.dtype == dtypes.only_int
             np.testing.assert_allclose(t.numpy(), np.array(arr))
 
         # mixture of bool, int and float
@@ -294,7 +294,7 @@ class TestTinygrad(unittest.TestCase):
             [[[True], [1]], [[3.0], [4]]],
         ):
             t = Tensor(arr)
-            assert t.dtype == dtypes.default_float
+            assert t.dtype == dtypes.only_float
             np.testing.assert_allclose(t.numpy(), np.array(arr))
     
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,223 +1,16 @@
 import numpy as np
-import torch
 import unittest, copy
 from edugrad import Tensor
 from edugrad.dtypes import dtypes
 
 
-from tests.gradcheck import numerical_jacobian, jacobian, gradcheck
-
-x_init = np.random.randn(1, 3).astype(np.float32)
-U_init = np.random.randn(3, 3).astype(np.float32)
-V_init = np.random.randn(3, 3).astype(np.float32)
-W_init = np.random.randn(3, 3).astype(np.float32)
-m_init = np.random.randn(1, 3).astype(np.float32)
-
-
 class TestTinygrad(unittest.TestCase):
-    def test_zerodim_initialization(self):
-        a = Tensor(55)
-        b = Tensor(3.14)
-
-        self.assertEqual(a.shape, ())
-        self.assertEqual(b.shape, ())
-
-    def test_plus_equals(self):
-        a = Tensor.randn(10, 10)
-        b = Tensor.randn(10, 10)
-        c = a + b
-        val1 = c.numpy()
-        a += b
-        val2 = a.numpy()
-        np.testing.assert_allclose(val1, val2)
-
-    def test_backward_pass(self):
-        def test_tinygrad():
-            x = Tensor(x_init, requires_grad=True)
-            W = Tensor(W_init, requires_grad=True)
-            m = Tensor(m_init)
-            out = x.dot(W).relu()
-            out = out.log_softmax()
-            out = out.mul(m).add(m).sum()
-            out.backward()
-            return out.numpy(), x.grad.numpy(), W.grad.numpy()
-
-        def test_pytorch():
-            x = torch.tensor(x_init, requires_grad=True)
-            W = torch.tensor(W_init, requires_grad=True)
-            m = torch.tensor(m_init)
-            out = x.matmul(W).relu()
-            out = torch.nn.functional.log_softmax(out, dim=1)
-            out = out.mul(m).add(m).sum()
-            out.backward()
-            return out.detach().numpy(), x.grad, W.grad
-
-        for x, y in zip(test_tinygrad(), test_pytorch()):
-            np.testing.assert_allclose(x, y, atol=1e-5)
-
-    # @unittest.skipIf(Device.DEFAULT == "WEBGPU", "this test uses more than 8 bufs which breaks webgpu") #TODO: remove after #1461
-    def test_backward_pass_diamond_model(self):
-        def test_tinygrad():
-            u = Tensor(U_init, requires_grad=True)
-            v = Tensor(V_init, requires_grad=True)
-            w = Tensor(W_init, requires_grad=True)
-            x = u.mul(v).relu()
-            y = u.mul(w).relu()
-            out = x.add(y).mul(y).relu()
-            out = out.log_softmax()
-            out = out.sum()
-            out.backward()
-            return out.numpy(), u.grad.numpy(), v.grad.numpy(), w.grad.numpy()
-
-        def test_pytorch():
-            u = torch.tensor(U_init, requires_grad=True)
-            v = torch.tensor(V_init, requires_grad=True)
-            w = torch.tensor(W_init, requires_grad=True)
-            x = u.mul(v).relu()
-            y = u.mul(w).relu()
-            out = x.add(y).mul(y).relu()
-            out = torch.nn.functional.log_softmax(out, dim=1)
-            out = out.sum()
-            out.backward()
-            return out.detach().numpy(), u.grad, v.grad, w.grad
-
-        for x, y in zip(test_tinygrad(), test_pytorch()):
-            np.testing.assert_allclose(x, y, atol=1e-5)
-
-    def test_nograd(self):
-        x = Tensor(x_init, requires_grad=False)
-        m = Tensor(m_init, requires_grad=False)
-        W = Tensor(W_init, requires_grad=True)
-        tmp = x.mul(m)
-        mm = tmp.matmul(W)
-        out = mm.relu()
-        out = out.sum()
-        out.backward()
-        assert x.grad is None
-        assert m.grad is None
-        assert tmp.grad is None
-        assert mm.grad is not None
-        assert W.grad is not None
-
-    def test_jacobian(self):
-        W = np.random.RandomState(42069).random((10, 5)).astype(np.float32)
-        x = np.random.RandomState(69420).random((1, 10)).astype(np.float32)
-
-        torch_x = torch.tensor(x, requires_grad=True)
-        torch_W = torch.tensor(W, requires_grad=True)
-
-        def torch_func(x):
-            return torch.nn.functional.log_softmax(x.matmul(torch_W).relu(), dim=1)
-
-        PJ = torch.autograd.functional.jacobian(torch_func, torch_x).squeeze().numpy()
-
-        tiny_x = Tensor(x, requires_grad=True)
-        tiny_W = Tensor(W, requires_grad=True)
-
-        def tiny_func(x):
-            return x.dot(tiny_W).relu().log_softmax()
-
-        J = jacobian(tiny_func, tiny_x)
-        NJ = numerical_jacobian(tiny_func, tiny_x)
-
-        np.testing.assert_allclose(PJ, J, atol=1e-5)
-        np.testing.assert_allclose(PJ, NJ, atol=1e-3)
-
-    def test_gradcheck(self):
-        W = np.random.RandomState(1337).random((10, 5)).astype(np.float32)
-        x = np.random.RandomState(7331).random((1, 10)).astype(np.float32)
-
-        tiny_x = Tensor(x, requires_grad=True)
-        tiny_W = Tensor(W, requires_grad=True)
-
-        def tiny_func(x):
-            return x.dot(tiny_W).relu().log_softmax()
-
-        self.assertTrue(gradcheck(tiny_func, tiny_x, eps=1e-3))
-
-        # coarse approx. since a "big" eps and the non-linearities of the model
-        self.assertFalse(gradcheck(tiny_func, tiny_x, eps=1e-5))
-
-    def test_random_fns_are_deterministic_with_seed(self):
-        for random_fn in [Tensor.randn, Tensor.normal, Tensor.uniform, Tensor.scaled_uniform]:
-            with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
-                Tensor.manual_seed(1337)
-                a = random_fn(10, 10)
-                Tensor.manual_seed(1337)
-                b = random_fn(10, 10)
-                np.testing.assert_allclose(a.numpy(), b.numpy())
-
-    def test_randn_isnt_inf_on_zero(self):
-        # simulate failure case of rand handing a zero to randn
-        original_rand, Tensor.rand = Tensor.rand, Tensor.zeros
-        try:
-            self.assertNotIn(np.inf, Tensor.randn(16).numpy())
-        except:
-            raise
-        finally:
-            Tensor.rand = original_rand
-
-    def test_zeros_like_has_same_dtype_and_shape(self):
-        for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
-            a = Tensor([1, 2, 3], dtype=datatype)
-            b = Tensor.zeros_like(a)
-            assert a.dtype == b.dtype, f"dtype mismatch {a.dtype=} != {b.dtype}"
-            assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
-
-        a = Tensor([1, 2, 3])
-        b = Tensor.zeros_like(a, dtype=dtypes.int8)
-        assert (
-            a.dtype == dtypes.only_int and b.dtype == dtypes.int8
-        ), "a.dtype should be int and b.dtype should be char"
-        assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
-
-    def test_ones_like_has_same_dtype_and_shape(self):
-        for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
-            a = Tensor([1, 2, 3], dtype=datatype)
-            b = Tensor.ones_like(a)
-            assert a.dtype == b.dtype, f"dtype mismatch {a.dtype=} != {b.dtype}"
-            assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
-
-        a = Tensor([1, 2, 3])
-        b = Tensor.ones_like(a, dtype=dtypes.int8)
-        assert (
-            a.dtype == dtypes.only_int and b.dtype == dtypes.int8
-        ), "a.dtype should be int and b.dtype should be char"
-        assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
 
     def test_ndim(self):
         assert Tensor(1).ndim == 0
         assert Tensor.randn(1).ndim == 1
         assert Tensor.randn(2, 2, 2).ndim == 3
         assert Tensor.randn(1, 1, 1, 1, 1, 1).ndim == 6
-
-    def test_argfix(self):
-        self.assertEqual(Tensor.zeros().shape, ())
-        self.assertEqual(Tensor.ones().shape, ())
-
-        self.assertEqual(Tensor.zeros([]).shape, ())
-        self.assertEqual(Tensor.ones([]).shape, ())
-
-        self.assertEqual(Tensor.zeros(tuple()).shape, ())
-        self.assertEqual(Tensor.ones(tuple()).shape, ())
-
-        self.assertEqual(Tensor.zeros(1).shape, (1,))
-        self.assertEqual(Tensor.ones(1).shape, (1,))
-
-        self.assertEqual(Tensor.zeros(1, 10, 20).shape, (1, 10, 20))
-        self.assertEqual(Tensor.ones(1, 10, 20).shape, (1, 10, 20))
-
-        self.assertEqual(Tensor.zeros([1]).shape, (1,))
-        self.assertEqual(Tensor.ones([1]).shape, (1,))
-
-        self.assertEqual(Tensor.zeros([10, 20, 40]).shape, (10, 20, 40))
-        self.assertEqual(Tensor.ones([10, 20, 40]).shape, (10, 20, 40))
-
-        self.assertEqual(Tensor.rand(1, 10, 20).shape, (1, 10, 20))
-        self.assertEqual(Tensor.rand((10, 20, 40)).shape, (10, 20, 40))
-
-        self.assertEqual(Tensor.empty(1, 10, 20).shape, (1, 10, 20))
-        self.assertEqual(Tensor.empty((10, 20, 40)).shape, (10, 20, 40))
 
     def test_numel(self):
         assert Tensor.randn(10, 10).numel() == 100
@@ -232,12 +25,6 @@ class TestTinygrad(unittest.TestCase):
                 dtype.itemsize == Tensor.randn(3, dtype=dtype).element_size()
             ), f"Tensor.element_size() not matching Tensor.dtype.itemsize for {dtype}"
 
-    def test_deepwalk_ctx_check(self):
-        layer = Tensor.uniform(1, 1, requires_grad=True)
-        x = Tensor.randn(1, 1, 1)
-        x.dot(layer).mean().backward()
-        x = Tensor.randn(1, 1, 1)
-        x.dot(layer).mean().backward()
 
     def test_zerosized_tensors(self):
         np.testing.assert_equal(Tensor([]).numpy(), np.array([]))
@@ -328,74 +115,6 @@ class TestTinygrad(unittest.TestCase):
             np.testing.assert_allclose(reshaped_item, a), a
 
 class TestZeroShapeTensor(unittest.TestCase):
-    def test_rand(self):
-        t = Tensor.rand(3, 2, 0)
-        assert t.shape == (3, 2, 0)
-        np.testing.assert_equal(t.numpy(), np.zeros((3, 2, 0)))
-        t = Tensor.rand(0)
-        assert t.shape == (0,)
-        np.testing.assert_equal(t.numpy(), np.zeros((0,)))
-        t = Tensor.rand(0, 0, 0)
-        assert t.shape == (0, 0, 0)
-        np.testing.assert_equal(t.numpy(), np.zeros((0, 0, 0)))
-
-    def test_full(self):
-        t = Tensor.zeros(3, 2, 0)
-        assert t.shape == (3, 2, 0)
-        np.testing.assert_equal(t.numpy(), np.zeros((3, 2, 0)))
-        t = Tensor.full((3, 2, 0), 12)
-        assert t.shape == (3, 2, 0)
-        np.testing.assert_equal(t.numpy(), np.full((3, 2, 0), 12))
-
-    def test_reshape(self):
-        t = Tensor.zeros(3, 2, 0)
-        a = t.reshape(7, 0)
-        assert a.shape == (7, 0)
-        np.testing.assert_equal(a.numpy(), np.zeros((7, 0)))
-        with self.assertRaises(ValueError):
-            # cannot reshape array of size 0 into shape ()
-            a = t.reshape(())
-
-    def test_expand(self):
-        t = Tensor.full((3, 2, 0), 12)
-        # with numpy operands could not be broadcast together with remapped shapes [original->remapped]: (3,2,0)
-        # and requested shape (6,2,0)
-        with self.assertRaises(ValueError):
-            t = t.expand((6, 2, 0))
-            # assert t.shape == (6, 2, 0)
-            # np.testing.assert_equal(t.numpy(), np.full((6, 2, 0), 12))
-
-    def test_pad(self):
-        t = Tensor.rand(3, 2, 0).pad((None, None, (1, 1)), 1)
-        assert t.shape == (3, 2, 2)
-        np.testing.assert_equal(t.numpy(), np.ones((3, 2, 2)))
-
-        # torch does not support padding non-zero dim with 0-size. torch.nn.functional.pad(torch.zeros(3,2,0), [0,0,0,4,0,0])
-        t = Tensor.rand(3, 2, 0).pad((None, (1, 1), None), 1)
-        assert t.shape == (3, 4, 0)
-        np.testing.assert_equal(t.numpy(), np.ones((3, 4, 0)))
-
-        t = Tensor.rand(3, 2, 0).pad(((1, 1), None, None), 1)
-        assert t.shape == (5, 2, 0)
-        np.testing.assert_equal(t.numpy(), np.ones((5, 2, 0)))
-
-    def test_shrink_into_zero(self):
-        t = Tensor.rand(3, 4)
-        assert t.shrink((None, (2, 2))).shape == (3, 0)
-        assert t.shrink(((2, 2), None)).shape == (0, 4)
-        assert t.shrink(((2, 2), (2, 2))).shape == (0, 0)
-
-    def test_cat(self):
-        s = Tensor.rand(3, 2, 2)
-        t = Tensor.rand(3, 2, 0).cat(s, dim=2)
-        assert t.shape == (3, 2, 2)
-        np.testing.assert_equal(t.numpy(), s.numpy())
-
-        # torch does not support padding non-zero dim with 0-size. torch.nn.functional.pad(torch.zeros(3,2,0), [0,0,0,4,0,0])
-        s = Tensor.rand(3, 4, 0)
-        t = Tensor.rand(3, 2, 0).cat(s, dim=1)
-        assert t.shape == (3, 6, 0)
-        np.testing.assert_equal(t.numpy(), np.zeros((3, 6, 0)))
 
     def test_elementwise(self):
         a = Tensor.rand(3, 2, 0)
@@ -414,26 +133,6 @@ class TestZeroShapeTensor(unittest.TestCase):
         c = mask.where(a, b)
         assert c.shape == (3, 2, 0)
         np.testing.assert_equal(c.numpy(), np.where(mask.numpy(), a.numpy(), b.numpy()))
-
-    def test_reduce_over_non_zero(self):
-        a = Tensor.ones(3, 2, 0).sum(axis=1)
-        assert a.shape == (3, 0)
-        np.testing.assert_equal(a.numpy(), np.sum(np.zeros((3, 2, 0)), axis=1))
-
-    def test_reduce_over_zero(self):
-        a = Tensor.ones(3, 2, 0).sum(axis=2)
-        assert a.shape == (3, 2)
-        np.testing.assert_equal(a.numpy(), np.sum(np.zeros((3, 2, 0)), axis=2))
-
-        a = Tensor.ones(3, 2, 0).sum(axis=2, keepdim=True)
-        assert a.shape == (3, 2, 1)
-        np.testing.assert_equal(a.numpy(), np.sum(np.zeros((3, 2, 0)), axis=2, keepdims=True))
-
-    def test_reduce_default(self):
-        np.testing.assert_equal(Tensor([]).max().numpy(), -float("inf"))
-        np.testing.assert_equal(Tensor([]).min().numpy(), float("inf"))
-        np.testing.assert_equal(Tensor([]).sum().numpy(), 0)
-        np.testing.assert_equal(Tensor([]).mean().numpy(), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,0 +1,446 @@
+import numpy as np
+import torch
+import unittest, copy, pytest
+from edugrad import Tensor
+from edugrad.dtypes import dtypes
+
+# from tinygrad.helpers import temp
+
+from tests.gradcheck import numerical_jacobian, jacobian, gradcheck
+
+x_init = np.random.randn(1, 3).astype(np.float32)
+U_init = np.random.randn(3, 3).astype(np.float32)
+V_init = np.random.randn(3, 3).astype(np.float32)
+W_init = np.random.randn(3, 3).astype(np.float32)
+m_init = np.random.randn(1, 3).astype(np.float32)
+
+
+class TestTinygrad(unittest.TestCase):
+    def test_zerodim_initialization(self):
+        a = Tensor(55)
+        b = Tensor(3.14)
+
+        self.assertEqual(a.shape, ())
+        self.assertEqual(b.shape, ())
+
+    def test_plus_equals(self):
+        a = Tensor.randn(10, 10)
+        b = Tensor.randn(10, 10)
+        c = a + b
+        val1 = c.numpy()
+        a += b
+        val2 = a.numpy()
+        np.testing.assert_allclose(val1, val2)
+
+    def test_backward_pass(self):
+        def test_tinygrad():
+            x = Tensor(x_init, requires_grad=True)
+            W = Tensor(W_init, requires_grad=True)
+            m = Tensor(m_init)
+            out = x.dot(W).relu()
+            out = out.log_softmax()
+            out = out.mul(m).add(m).sum()
+            out.backward()
+            return out.numpy(), x.grad.numpy(), W.grad.numpy()
+
+        def test_pytorch():
+            x = torch.tensor(x_init, requires_grad=True)
+            W = torch.tensor(W_init, requires_grad=True)
+            m = torch.tensor(m_init)
+            out = x.matmul(W).relu()
+            out = torch.nn.functional.log_softmax(out, dim=1)
+            out = out.mul(m).add(m).sum()
+            out.backward()
+            return out.detach().numpy(), x.grad, W.grad
+
+        for x, y in zip(test_tinygrad(), test_pytorch()):
+            np.testing.assert_allclose(x, y, atol=1e-5)
+
+    # @unittest.skipIf(Device.DEFAULT == "WEBGPU", "this test uses more than 8 bufs which breaks webgpu") #TODO: remove after #1461
+    def test_backward_pass_diamond_model(self):
+        def test_tinygrad():
+            u = Tensor(U_init, requires_grad=True)
+            v = Tensor(V_init, requires_grad=True)
+            w = Tensor(W_init, requires_grad=True)
+            x = u.mul(v).relu()
+            y = u.mul(w).relu()
+            out = x.add(y).mul(y).relu()
+            out = out.log_softmax()
+            out = out.sum()
+            out.backward()
+            return out.numpy(), u.grad.numpy(), v.grad.numpy(), w.grad.numpy()
+
+        def test_pytorch():
+            u = torch.tensor(U_init, requires_grad=True)
+            v = torch.tensor(V_init, requires_grad=True)
+            w = torch.tensor(W_init, requires_grad=True)
+            x = u.mul(v).relu()
+            y = u.mul(w).relu()
+            out = x.add(y).mul(y).relu()
+            out = torch.nn.functional.log_softmax(out, dim=1)
+            out = out.sum()
+            out.backward()
+            return out.detach().numpy(), u.grad, v.grad, w.grad
+
+        for x, y in zip(test_tinygrad(), test_pytorch()):
+            np.testing.assert_allclose(x, y, atol=1e-5)
+
+    def test_nograd(self):
+        x = Tensor(x_init, requires_grad=False)
+        m = Tensor(m_init, requires_grad=False)
+        W = Tensor(W_init, requires_grad=True)
+        tmp = x.mul(m)
+        mm = tmp.matmul(W)
+        out = mm.relu()
+        out = out.sum()
+        out.backward()
+        assert x.grad is None
+        assert m.grad is None
+        assert tmp.grad is None
+        assert mm.grad is not None
+        assert W.grad is not None
+
+    def test_jacobian(self):
+        W = np.random.RandomState(42069).random((10, 5)).astype(np.float32)
+        x = np.random.RandomState(69420).random((1, 10)).astype(np.float32)
+
+        torch_x = torch.tensor(x, requires_grad=True)
+        torch_W = torch.tensor(W, requires_grad=True)
+
+        def torch_func(x):
+            return torch.nn.functional.log_softmax(x.matmul(torch_W).relu(), dim=1)
+
+        PJ = torch.autograd.functional.jacobian(torch_func, torch_x).squeeze().numpy()
+
+        tiny_x = Tensor(x, requires_grad=True)
+        tiny_W = Tensor(W, requires_grad=True)
+
+        def tiny_func(x):
+            return x.dot(tiny_W).relu().log_softmax()
+
+        J = jacobian(tiny_func, tiny_x)
+        NJ = numerical_jacobian(tiny_func, tiny_x)
+
+        np.testing.assert_allclose(PJ, J, atol=1e-5)
+        np.testing.assert_allclose(PJ, NJ, atol=1e-3)
+
+    def test_gradcheck(self):
+        W = np.random.RandomState(1337).random((10, 5)).astype(np.float32)
+        x = np.random.RandomState(7331).random((1, 10)).astype(np.float32)
+
+        tiny_x = Tensor(x, requires_grad=True)
+        tiny_W = Tensor(W, requires_grad=True)
+
+        def tiny_func(x):
+            return x.dot(tiny_W).relu().log_softmax()
+
+        self.assertTrue(gradcheck(tiny_func, tiny_x, eps=1e-3))
+
+        # coarse approx. since a "big" eps and the non-linearities of the model
+        self.assertFalse(gradcheck(tiny_func, tiny_x, eps=1e-5))
+
+    def test_random_fns_are_deterministic_with_seed(self):
+        for random_fn in [Tensor.randn, Tensor.normal, Tensor.uniform, Tensor.scaled_uniform]:
+            with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
+                Tensor.manual_seed(1337)
+                a = random_fn(10, 10)
+                Tensor.manual_seed(1337)
+                b = random_fn(10, 10)
+                np.testing.assert_allclose(a.numpy(), b.numpy())
+
+    def test_randn_isnt_inf_on_zero(self):
+        # simulate failure case of rand handing a zero to randn
+        original_rand, Tensor.rand = Tensor.rand, Tensor.zeros
+        try:
+            self.assertNotIn(np.inf, Tensor.randn(16).numpy())
+        except:
+            raise
+        finally:
+            Tensor.rand = original_rand
+
+    @pytest.mark.skip(reason="We cast lists of all dtypes up to floats when moving to Tensor")
+    def test_zeros_like_has_same_dtype_and_shape(self):
+        for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
+            a = Tensor([1, 2, 3], dtype=datatype)
+            b = Tensor.zeros_like(a)
+            assert a.dtype == b.dtype, f"dtype mismatch {a.dtype=} != {b.dtype}"
+            assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
+
+        a = Tensor([1, 2, 3])
+        b = Tensor.zeros_like(a, dtype=dtypes.int8)
+        assert (
+            a.dtype == dtypes.default_int and b.dtype == dtypes.int8
+        ), "a.dtype should be int and b.dtype should be char"
+        assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
+
+    @pytest.mark.skip(reason="We cast lists of all dtypes up to floats when moving to Tensor")
+    def test_ones_like_has_same_dtype_and_shape(self):
+        for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
+            a = Tensor([1, 2, 3], dtype=datatype)
+            b = Tensor.ones_like(a)
+            assert a.dtype == b.dtype, f"dtype mismatch {a.dtype=} != {b.dtype}"
+            assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
+
+        a = Tensor([1, 2, 3])
+        b = Tensor.ones_like(a, dtype=dtypes.int8)
+        assert (
+            a.dtype == dtypes.default_int and b.dtype == dtypes.int8
+        ), "a.dtype should be int and b.dtype should be char"
+        assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
+
+    def test_ndim(self):
+        assert Tensor(1).ndim == 0
+        assert Tensor.randn(1).ndim == 1
+        assert Tensor.randn(2, 2, 2).ndim == 3
+        assert Tensor.randn(1, 1, 1, 1, 1, 1).ndim == 6
+
+    def test_argfix(self):
+        self.assertEqual(Tensor.zeros().shape, ())
+        self.assertEqual(Tensor.ones().shape, ())
+
+        self.assertEqual(Tensor.zeros([]).shape, ())
+        self.assertEqual(Tensor.ones([]).shape, ())
+
+        self.assertEqual(Tensor.zeros(tuple()).shape, ())
+        self.assertEqual(Tensor.ones(tuple()).shape, ())
+
+        self.assertEqual(Tensor.zeros(1).shape, (1,))
+        self.assertEqual(Tensor.ones(1).shape, (1,))
+
+        self.assertEqual(Tensor.zeros(1, 10, 20).shape, (1, 10, 20))
+        self.assertEqual(Tensor.ones(1, 10, 20).shape, (1, 10, 20))
+
+        self.assertEqual(Tensor.zeros([1]).shape, (1,))
+        self.assertEqual(Tensor.ones([1]).shape, (1,))
+
+        self.assertEqual(Tensor.zeros([10, 20, 40]).shape, (10, 20, 40))
+        self.assertEqual(Tensor.ones([10, 20, 40]).shape, (10, 20, 40))
+
+        self.assertEqual(Tensor.rand(1, 10, 20).shape, (1, 10, 20))
+        self.assertEqual(Tensor.rand((10, 20, 40)).shape, (10, 20, 40))
+
+        self.assertEqual(Tensor.empty(1, 10, 20).shape, (1, 10, 20))
+        self.assertEqual(Tensor.empty((10, 20, 40)).shape, (10, 20, 40))
+
+    def test_numel(self):
+        assert Tensor.randn(10, 10).numel() == 100
+        assert Tensor.randn(1, 2, 5).numel() == 10
+        assert Tensor.randn(1, 1, 1, 1, 1, 1).numel() == 1
+        assert Tensor([]).numel() == 0
+        assert Tensor.randn(1, 0, 2, 5).numel() == 0
+
+    def test_element_size(self):
+        for _, dtype in dtypes.fields().items():
+            assert (
+                dtype.itemsize == Tensor.randn(3, dtype=dtype).element_size()
+            ), f"Tensor.element_size() not matching Tensor.dtype.itemsize for {dtype}"
+
+    def test_deepwalk_ctx_check(self):
+        layer = Tensor.uniform(1, 1, requires_grad=True)
+        x = Tensor.randn(1, 1, 1)
+        x.dot(layer).mean().backward()
+        x = Tensor.randn(1, 1, 1)
+        x.dot(layer).mean().backward()
+
+    def test_zerosized_tensors(self):
+        np.testing.assert_equal(Tensor([]).numpy(), np.array([]))
+        np.testing.assert_equal(Tensor(None).numpy(), np.array([]))
+
+    def test_tensor_ndarray_dtype(self):
+        arr = np.array([1])  # where dtype is implicitly int64
+        assert Tensor(arr).dtype == dtypes.int64
+        assert (
+            Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32
+        )  # check if ndarray correctly casts to Tensor dtype
+        assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64  # check that it works for something else
+
+    
+    @pytest.mark.skip(reason="We cast lists of all dtypes up to floats when moving to Tensor")
+    def test_tensor_list_dtype(self):
+        for arr in ([1], [[[1]]], [[1, 1], [1, 1]], [[[1, 1], [1, 1]], [[1, 1], [1, 1]]]):
+            x = Tensor(arr)
+            have = x.dtype
+            assert Tensor(arr).dtype == dtypes.default_int
+            assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32
+            assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64
+
+        for arr in (
+            [True],
+            [[[False]]],
+            [[True, False], [True, False]],
+            [[[False, True], [False, False]], [[True, True], [False, True]]],
+        ):
+            assert Tensor(arr).dtype == dtypes.bool
+            assert Tensor(arr, dtype=dtypes.float32).dtype == dtypes.float32
+            assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64
+
+        # empty tensor defaults
+        for arr in ([], [[[]]], [[], []]):
+            t = Tensor(arr)
+            assert t.dtype == dtypes.default_float
+            np.testing.assert_allclose(t.numpy(), np.array(arr))
+
+        # mixture of bool and int
+        for arr in ([True, 3], [[True], [3]], [[[True]], [[3]]], [[True, 3], [3, True]]):
+            t = Tensor(arr)
+            assert t.dtype == dtypes.default_int
+            np.testing.assert_allclose(t.numpy(), np.array(arr))
+
+        # mixture of bool, int and float
+        for arr in (
+            [[True, True], [3.0, True]],
+            [[0, 1], [3.0, 4]],
+            [[[0], [1]], [[3.0], [4]]],
+            [[[True], [1]], [[3.0], [4]]],
+        ):
+            t = Tensor(arr)
+            assert t.dtype == dtypes.default_float
+            np.testing.assert_allclose(t.numpy(), np.array(arr))
+    
+
+    def test_tensor_list_shapes(self):
+        self.assertEqual(Tensor([[[]]]).shape, (1, 1, 0))
+        self.assertEqual(Tensor([[], []]).shape, (2, 0))
+        self.assertEqual(Tensor([[[[]], [[]]], [[[]], [[]]], [[[]], [[]]]]).shape, (3, 2, 1, 0))
+
+    def test_tensor_list_errors(self):
+        # inhomogeneous shape
+        with self.assertRaises(ValueError):
+            Tensor([[], [[]]])
+        with self.assertRaises(ValueError):
+            Tensor([[1], []])
+        with self.assertRaises(ValueError):
+            Tensor([[1], [1], 1])
+        with self.assertRaises(ValueError):
+            Tensor([[[1, 1, 1], [1, 1]]])
+        with self.assertRaises(ValueError):
+            Tensor([[1, 1, 1], [[1, 1, 1]]])
+
+    def test_tensor_copy(self):
+        x = copy.deepcopy(Tensor.ones((3, 3, 3)))
+        np.testing.assert_allclose(x.numpy(), np.ones((3, 3, 3)))
+
+    @pytest.mark.skip(reason="We cast lists of all dtypes up to floats when moving to Tensor")
+    def test_item_to_tensor_to_item(self):
+        for a in [0, 1, 2, 3, -1, -100, 100, -101.1, 2.345, 100.1, True, False]:
+            item = Tensor(a).item()
+            assert type(item) == type(a), a
+            np.testing.assert_allclose(item, a), a
+            buffered_item = Tensor([a]).item()
+            assert type(buffered_item) == type(a), a
+            np.testing.assert_allclose(buffered_item, a), a
+            reshaped_item = Tensor([a]).reshape((1, 1, 1, 1, 1)).item()
+            assert type(reshaped_item) == type(a), a
+            np.testing.assert_allclose(reshaped_item, a), a
+
+class TestZeroShapeTensor(unittest.TestCase):
+    def test_rand(self):
+        t = Tensor.rand(3, 2, 0)
+        assert t.shape == (3, 2, 0)
+        np.testing.assert_equal(t.numpy(), np.zeros((3, 2, 0)))
+        t = Tensor.rand(0)
+        assert t.shape == (0,)
+        np.testing.assert_equal(t.numpy(), np.zeros((0,)))
+        t = Tensor.rand(0, 0, 0)
+        assert t.shape == (0, 0, 0)
+        np.testing.assert_equal(t.numpy(), np.zeros((0, 0, 0)))
+
+    def test_full(self):
+        t = Tensor.zeros(3, 2, 0)
+        assert t.shape == (3, 2, 0)
+        np.testing.assert_equal(t.numpy(), np.zeros((3, 2, 0)))
+        t = Tensor.full((3, 2, 0), 12)
+        assert t.shape == (3, 2, 0)
+        np.testing.assert_equal(t.numpy(), np.full((3, 2, 0), 12))
+
+    def test_reshape(self):
+        t = Tensor.zeros(3, 2, 0)
+        a = t.reshape(7, 0)
+        assert a.shape == (7, 0)
+        np.testing.assert_equal(a.numpy(), np.zeros((7, 0)))
+        with self.assertRaises(ValueError):
+            # cannot reshape array of size 0 into shape ()
+            a = t.reshape(())
+
+    def test_expand(self):
+        t = Tensor.full((3, 2, 0), 12)
+        # with numpy operands could not be broadcast together with remapped shapes [original->remapped]: (3,2,0)
+        # and requested shape (6,2,0)
+        with self.assertRaises(ValueError):
+            t = t.expand((6, 2, 0))
+            # assert t.shape == (6, 2, 0)
+            # np.testing.assert_equal(t.numpy(), np.full((6, 2, 0), 12))
+
+    def test_pad(self):
+        t = Tensor.rand(3, 2, 0).pad((None, None, (1, 1)), 1)
+        assert t.shape == (3, 2, 2)
+        np.testing.assert_equal(t.numpy(), np.ones((3, 2, 2)))
+
+        # torch does not support padding non-zero dim with 0-size. torch.nn.functional.pad(torch.zeros(3,2,0), [0,0,0,4,0,0])
+        t = Tensor.rand(3, 2, 0).pad((None, (1, 1), None), 1)
+        assert t.shape == (3, 4, 0)
+        np.testing.assert_equal(t.numpy(), np.ones((3, 4, 0)))
+
+        t = Tensor.rand(3, 2, 0).pad(((1, 1), None, None), 1)
+        assert t.shape == (5, 2, 0)
+        np.testing.assert_equal(t.numpy(), np.ones((5, 2, 0)))
+
+    def test_shrink_into_zero(self):
+        t = Tensor.rand(3, 4)
+        assert t.shrink((None, (2, 2))).shape == (3, 0)
+        assert t.shrink(((2, 2), None)).shape == (0, 4)
+        assert t.shrink(((2, 2), (2, 2))).shape == (0, 0)
+
+    def test_cat(self):
+        s = Tensor.rand(3, 2, 2)
+        t = Tensor.rand(3, 2, 0).cat(s, dim=2)
+        assert t.shape == (3, 2, 2)
+        np.testing.assert_equal(t.numpy(), s.numpy())
+
+        # torch does not support padding non-zero dim with 0-size. torch.nn.functional.pad(torch.zeros(3,2,0), [0,0,0,4,0,0])
+        s = Tensor.rand(3, 4, 0)
+        t = Tensor.rand(3, 2, 0).cat(s, dim=1)
+        assert t.shape == (3, 6, 0)
+        np.testing.assert_equal(t.numpy(), np.zeros((3, 6, 0)))
+
+    def test_elementwise(self):
+        a = Tensor.rand(3, 2, 0)
+        a_exp = a.exp()
+        assert a_exp.shape == (3, 2, 0)
+        np.testing.assert_equal(a_exp.numpy(), np.exp(a.numpy()))
+
+        b = Tensor.rand(3, 2, 0)
+        assert b.shape == (3, 2, 0)
+        ab = a * b
+        assert ab.shape == (3, 2, 0)
+        np.testing.assert_equal(ab.numpy(), a.numpy() * b.numpy())
+
+        mask = Tensor.rand(3, 2, 0) > 0.5
+        assert mask.shape == (3, 2, 0)
+        c = mask.where(a, b)
+        assert c.shape == (3, 2, 0)
+        np.testing.assert_equal(c.numpy(), np.where(mask.numpy(), a.numpy(), b.numpy()))
+
+    def test_reduce_over_non_zero(self):
+        a = Tensor.ones(3, 2, 0).sum(axis=1)
+        assert a.shape == (3, 0)
+        np.testing.assert_equal(a.numpy(), np.sum(np.zeros((3, 2, 0)), axis=1))
+
+    def test_reduce_over_zero(self):
+        a = Tensor.ones(3, 2, 0).sum(axis=2)
+        assert a.shape == (3, 2)
+        np.testing.assert_equal(a.numpy(), np.sum(np.zeros((3, 2, 0)), axis=2))
+
+        a = Tensor.ones(3, 2, 0).sum(axis=2, keepdim=True)
+        assert a.shape == (3, 2, 1)
+        np.testing.assert_equal(a.numpy(), np.sum(np.zeros((3, 2, 0)), axis=2, keepdims=True))
+
+    def test_reduce_default(self):
+        np.testing.assert_equal(Tensor([]).max().numpy(), -float("inf"))
+        np.testing.assert_equal(Tensor([]).min().numpy(), float("inf"))
+        np.testing.assert_equal(Tensor([]).sum().numpy(), 0)
+        np.testing.assert_equal(Tensor([]).mean().numpy(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,10 +1,9 @@
 import numpy as np
 import torch
-import unittest, copy, pytest
+import unittest, copy
 from edugrad import Tensor
 from edugrad.dtypes import dtypes
 
-# from tinygrad.helpers import temp
 
 from tests.gradcheck import numerical_jacobian, jacobian, gradcheck
 
@@ -158,7 +157,6 @@ class TestTinygrad(unittest.TestCase):
         finally:
             Tensor.rand = original_rand
 
-    @pytest.mark.skip(reason="We cast lists of all dtypes up to floats when moving to Tensor")
     def test_zeros_like_has_same_dtype_and_shape(self):
         for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
             a = Tensor([1, 2, 3], dtype=datatype)
@@ -173,7 +171,6 @@ class TestTinygrad(unittest.TestCase):
         ), "a.dtype should be int and b.dtype should be char"
         assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
 
-    @pytest.mark.skip(reason="We cast lists of all dtypes up to floats when moving to Tensor")
     def test_ones_like_has_same_dtype_and_shape(self):
         for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
             a = Tensor([1, 2, 3], dtype=datatype)
@@ -254,8 +251,6 @@ class TestTinygrad(unittest.TestCase):
         )  # check if ndarray correctly casts to Tensor dtype
         assert Tensor(arr, dtype=dtypes.float64).dtype == dtypes.float64  # check that it works for something else
 
-    
-    @pytest.mark.skip(reason="We cast lists of all dtypes up to floats when moving to Tensor")
     def test_tensor_list_dtype(self):
         for arr in ([1], [[[1]]], [[1, 1], [1, 1]], [[[1, 1], [1, 1]], [[1, 1], [1, 1]]]):
             x = Tensor(arr)
@@ -320,7 +315,6 @@ class TestTinygrad(unittest.TestCase):
         x = copy.deepcopy(Tensor.ones((3, 3, 3)))
         np.testing.assert_allclose(x.numpy(), np.ones((3, 3, 3)))
 
-    @pytest.mark.skip(reason="We cast lists of all dtypes up to floats when moving to Tensor")
     def test_item_to_tensor_to_item(self):
         for a in [0, 1, 2, 3, -1, -100, 100, -101.1, 2.345, 100.1, True, False]:
             item = Tensor(a).item()

--- a/tests/test_tensor_combine_segment.py
+++ b/tests/test_tensor_combine_segment.py
@@ -1,0 +1,17 @@
+import numpy as np
+import unittest
+from edugrad import Tensor
+
+
+class TestZeroShapeTensor(unittest.TestCase):
+    def test_cat(self):
+        s = Tensor.rand(3, 2, 2)
+        t = Tensor.rand(3, 2, 0).cat(s, dim=2)
+        assert t.shape == (3, 2, 2)
+        np.testing.assert_equal(t.numpy(), s.numpy())
+
+        # torch does not support padding non-zero dim with 0-size. torch.nn.functional.pad(torch.zeros(3,2,0), [0,0,0,4,0,0])
+        s = Tensor.rand(3, 4, 0)
+        t = Tensor.rand(3, 2, 0).cat(s, dim=1)
+        assert t.shape == (3, 6, 0)
+        np.testing.assert_equal(t.numpy(), np.zeros((3, 6, 0)))

--- a/tests/test_tensor_create.py
+++ b/tests/test_tensor_create.py
@@ -1,0 +1,90 @@
+import numpy as np
+import unittest
+from edugrad import Tensor
+from edugrad.dtypes import dtypes
+
+
+class TestTinygrad(unittest.TestCase):
+    def test_zerodim_initialization(self):
+        a = Tensor(55)
+        b = Tensor(3.14)
+
+        self.assertEqual(a.shape, ())
+        self.assertEqual(b.shape, ())
+
+    def test_plus_equals(self):
+        a = Tensor.randn(10, 10)
+        b = Tensor.randn(10, 10)
+        c = a + b
+        val1 = c.numpy()
+        a += b
+        val2 = a.numpy()
+        np.testing.assert_allclose(val1, val2)
+
+    def test_random_fns_are_deterministic_with_seed(self):
+        for random_fn in [Tensor.randn, Tensor.normal, Tensor.uniform, Tensor.scaled_uniform]:
+            with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
+                Tensor.manual_seed(1337)
+                a = random_fn(10, 10)
+                Tensor.manual_seed(1337)
+                b = random_fn(10, 10)
+                np.testing.assert_allclose(a.numpy(), b.numpy())
+
+    def test_randn_isnt_inf_on_zero(self):
+        # simulate failure case of rand handing a zero to randn
+        original_rand, Tensor.rand = Tensor.rand, Tensor.zeros
+        try:
+            self.assertNotIn(np.inf, Tensor.randn(16).numpy())
+        except:
+            raise
+        finally:
+            Tensor.rand = original_rand
+
+    def test_zeros_like_has_same_dtype_and_shape(self):
+        for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
+            a = Tensor([1, 2, 3], dtype=datatype)
+            b = Tensor.zeros_like(a)
+            assert a.dtype == b.dtype, f"dtype mismatch {a.dtype=} != {b.dtype}"
+            assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
+
+        a = Tensor([1, 2, 3])
+        b = Tensor.zeros_like(a, dtype=dtypes.int8)
+        assert (
+            a.dtype == dtypes.only_int and b.dtype == dtypes.int8
+        ), "a.dtype should be int and b.dtype should be char"
+        assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
+
+    def test_ones_like_has_same_dtype_and_shape(self):
+        for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
+            a = Tensor([1, 2, 3], dtype=datatype)
+            b = Tensor.ones_like(a)
+            assert a.dtype == b.dtype, f"dtype mismatch {a.dtype=} != {b.dtype}"
+            assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
+
+        a = Tensor([1, 2, 3])
+        b = Tensor.ones_like(a, dtype=dtypes.int8)
+        assert (
+            a.dtype == dtypes.only_int and b.dtype == dtypes.int8
+        ), "a.dtype should be int and b.dtype should be char"
+        assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
+
+
+class TestZeroShapeTensor(unittest.TestCase):
+    def test_rand(self):
+        t = Tensor.rand(3, 2, 0)
+        assert t.shape == (3, 2, 0)
+        np.testing.assert_equal(t.numpy(), np.zeros((3, 2, 0)))
+        t = Tensor.rand(0)
+        assert t.shape == (0,)
+        np.testing.assert_equal(t.numpy(), np.zeros((0,)))
+        t = Tensor.rand(0, 0, 0)
+        assert t.shape == (0, 0, 0)
+        np.testing.assert_equal(t.numpy(), np.zeros((0, 0, 0)))
+
+    def test_full(self):
+        t = Tensor.zeros(3, 2, 0)
+        assert t.shape == (3, 2, 0)
+        np.testing.assert_equal(t.numpy(), np.zeros((3, 2, 0)))
+        t = Tensor.full((3, 2, 0), 12)
+        assert t.shape == (3, 2, 0)
+        np.testing.assert_equal(t.numpy(), np.full((3, 2, 0), 12))

--- a/tests/test_tensor_create.py
+++ b/tests/test_tensor_create.py
@@ -4,7 +4,7 @@ from edugrad import Tensor
 from edugrad.dtypes import dtypes
 
 
-class TestTinygrad(unittest.TestCase):
+class TestEdugrad(unittest.TestCase):
     def test_zerodim_initialization(self):
         a = Tensor(55)
         b = Tensor(3.14)
@@ -41,32 +41,19 @@ class TestTinygrad(unittest.TestCase):
             Tensor.rand = original_rand
 
     def test_zeros_like_has_same_dtype_and_shape(self):
-        for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
+        for datatype in [dtypes.float32, dtypes.int32]:
             a = Tensor([1, 2, 3], dtype=datatype)
             b = Tensor.zeros_like(a)
             assert a.dtype == b.dtype, f"dtype mismatch {a.dtype=} != {b.dtype}"
             assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
 
-        a = Tensor([1, 2, 3])
-        b = Tensor.zeros_like(a, dtype=dtypes.int8)
-        assert (
-            a.dtype == dtypes.only_int and b.dtype == dtypes.int8
-        ), "a.dtype should be int and b.dtype should be char"
-        assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
 
     def test_ones_like_has_same_dtype_and_shape(self):
-        for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
+        for datatype in [dtypes.float32, dtypes.int32]:
             a = Tensor([1, 2, 3], dtype=datatype)
             b = Tensor.ones_like(a)
             assert a.dtype == b.dtype, f"dtype mismatch {a.dtype=} != {b.dtype}"
             assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
-
-        a = Tensor([1, 2, 3])
-        b = Tensor.ones_like(a, dtype=dtypes.int8)
-        assert (
-            a.dtype == dtypes.only_int and b.dtype == dtypes.int8
-        ), "a.dtype should be int and b.dtype should be char"
-        assert a.shape == b.shape, f"shape mismatch {a.shape} != {b.shape}"
 
 
 class TestZeroShapeTensor(unittest.TestCase):

--- a/tests/test_tensor_reduce.py
+++ b/tests/test_tensor_reduce.py
@@ -1,0 +1,27 @@
+import numpy as np
+import unittest, copy
+from edugrad import Tensor
+from edugrad.dtypes import dtypes
+
+
+class TestZeroShapeTensor(unittest.TestCase):
+
+    def test_reduce_over_non_zero(self):
+        a = Tensor.ones(3, 2, 0).sum(axis=1)
+        assert a.shape == (3, 0)
+        np.testing.assert_equal(a.numpy(), np.sum(np.zeros((3, 2, 0)), axis=1))
+
+    def test_reduce_over_zero(self):
+        a = Tensor.ones(3, 2, 0).sum(axis=2)
+        assert a.shape == (3, 2)
+        np.testing.assert_equal(a.numpy(), np.sum(np.zeros((3, 2, 0)), axis=2))
+
+        a = Tensor.ones(3, 2, 0).sum(axis=2, keepdim=True)
+        assert a.shape == (3, 2, 1)
+        np.testing.assert_equal(a.numpy(), np.sum(np.zeros((3, 2, 0)), axis=2, keepdims=True))
+
+    def test_reduce_default(self):
+        np.testing.assert_equal(Tensor([]).max().numpy(), -float("inf"))
+        np.testing.assert_equal(Tensor([]).min().numpy(), float("inf"))
+        np.testing.assert_equal(Tensor([]).sum().numpy(), 0)
+        np.testing.assert_equal(Tensor([]).mean().numpy(), 0)

--- a/tests/test_tensor_reshape.py
+++ b/tests/test_tensor_reshape.py
@@ -1,0 +1,43 @@
+import numpy as np
+import unittest
+from edugrad import Tensor
+
+
+class TestZeroShapeTensor(unittest.TestCase):
+    def test_reshape(self):
+        t = Tensor.zeros(3, 2, 0)
+        a = t.reshape(7, 0)
+        assert a.shape == (7, 0)
+        np.testing.assert_equal(a.numpy(), np.zeros((7, 0)))
+        with self.assertRaises(ValueError):
+            # cannot reshape array of size 0 into shape ()
+            a = t.reshape(())
+
+    def test_expand(self):
+        t = Tensor.full((3, 2, 0), 12)
+        # with numpy operands could not be broadcast together with remapped shapes [original->remapped]: (3,2,0)
+        # and requested shape (6,2,0)
+        with self.assertRaises(ValueError):
+            t = t.expand((6, 2, 0))
+            # assert t.shape == (6, 2, 0)
+            # np.testing.assert_equal(t.numpy(), np.full((6, 2, 0), 12))
+
+    def test_pad(self):
+        t = Tensor.rand(3, 2, 0).pad((None, None, (1, 1)), 1)
+        assert t.shape == (3, 2, 2)
+        np.testing.assert_equal(t.numpy(), np.ones((3, 2, 2)))
+
+        # torch does not support padding non-zero dim with 0-size. torch.nn.functional.pad(torch.zeros(3,2,0), [0,0,0,4,0,0])
+        t = Tensor.rand(3, 2, 0).pad((None, (1, 1), None), 1)
+        assert t.shape == (3, 4, 0)
+        np.testing.assert_equal(t.numpy(), np.ones((3, 4, 0)))
+
+        t = Tensor.rand(3, 2, 0).pad(((1, 1), None, None), 1)
+        assert t.shape == (5, 2, 0)
+        np.testing.assert_equal(t.numpy(), np.ones((5, 2, 0)))
+
+    def test_shrink_into_zero(self):
+        t = Tensor.rand(3, 4)
+        assert t.shrink((None, (2, 2))).shape == (3, 0)
+        assert t.shrink(((2, 2), None)).shape == (0, 4)
+        assert t.shrink(((2, 2), (2, 2))).shape == (0, 0)


### PR DESCRIPTION
- bugfixes
- due to dtype related bugs:
  - move dtypes to own module
  - **only allow bool, int32 and float32**
  **-  Only allow float32 when Tensor(list). (Perhaps allow bool, int32, too if list is only bool, and only int32 in the future?)** -> Yet most operations in TensorData cast to float32 anyways.

- ingetration test for mnist test acc > 93 %
- unit tests for tensor distributed over according modules